### PR TITLE
__restrict__ should be after the *

### DIFF
--- a/hydra/detail/functors/DecayMother.h
+++ b/hydra/detail/functors/DecayMother.h
@@ -75,7 +75,7 @@ struct DecayMother
 	GReal_t fBeta2;
 
 
-	//const GReal_t* __restrict__ fMasses;
+	//const GReal_t __restrict__ *fMasses;
 	GReal_t fMasses[N];
 
 	//constructor

--- a/hydra/detail/functors/ProcessCallsPlain.h
+++ b/hydra/detail/functors/ProcessCallsPlain.h
@@ -93,8 +93,8 @@ struct ProcessCallsPlainUnary
 	}
 
 	FUNCTOR fFunctor;
-	GReal_t __restrict__ *fXLow;
-	GReal_t __restrict__ *fDeltaX;
+	GReal_t* __restrict__ fXLow;
+	GReal_t* __restrict__ fDeltaX;
 };
 
 

--- a/hydra/detail/functors/ProcessCallsVegas.h
+++ b/hydra/detail/functors/ProcessCallsVegas.h
@@ -246,10 +246,10 @@ private:
     GInt_t  fSeed ;
     GInt_t fMode;
 
-   GReal_t __restrict__ *fXi;
-   GReal_t __restrict__ *fXLow;
-   GReal_t __restrict__ *fDeltaX;
-   GFloat_t  __restrict__ *fDistribution;
+   GReal_t* __restrict__ fXi;
+   GReal_t* __restrict__ fXLow;
+   GReal_t* __restrict__ fDeltaX;
+   GFloat_t*  __restrict__ fDistribution;
 
     FUNCTOR fFunctor;
 


### PR DESCRIPTION
The * was before the __restrict__ in a few cases, which causes an error on compilers like clang.