### PR TITLE
Fix for missing includes (causes CPP backend to fail)

### DIFF
--- a/hydra/Events.h
+++ b/hydra/Events.h
@@ -47,6 +47,8 @@
 #include <stdio.h>
 
 #include <thrust/copy.h>
+#include <thrust/count.h>
+#include <thrust/extrema.h>
 
 #include <hydra/detail/Config.h>
 #include <hydra/Types.h>

--- a/hydra/Random.h
+++ b/hydra/Random.h
@@ -45,6 +45,7 @@
 #include <hydra/PointVector.h>
 //
 #include <thrust/copy.h>
+#include <thrust/count.h>
 #include <thrust/random.h>
 #include <thrust/distance.h>
 #include <thrust/extrema.h>


### PR DESCRIPTION
These thrust includes were missing, but somehow slip in unless you set the backend to CPP.