### PR TITLE
C++20 concept implementations 

### DIFF
--- a/hydra/Convolution.h
+++ b/hydra/Convolution.h
@@ -49,6 +49,8 @@
 #endif
 #include <utility>
 #include <type_traits>
+#include <hydra/detail/IteratorConcepts.h>
+#include <concepts>
 
 #if HYDRA_DEVICE_SYSTEM == CUDA
 #define TYPE typename std::conditional< std::is_convertible<detail::BackendPolicy<BACKEND>,hydra::thrust::system::cuda::tag >::value, std::integral_constant<int, 1>,std::integral_constant<int, 0>>::type
@@ -65,10 +67,8 @@ template<detail::Backend BACKEND, detail::FFTCalculator FFTBackend,  typename Fu
      typename USING_CUDA_BACKEND = TYPE,
      typename USING_CUFFT = typename std::conditional< FFTBackend==detail::CuFFT, std::integral_constant<int, 1>,std::integral_constant<int, 0>>::type,
      typename GPU_DATA = TAG>
-inline typename std::enable_if<std::is_floating_point<T>::value  && hydra::detail::is_iterable<Iterable>::value
-                   // && (USING_CUDA_BACKEND::value == USING_CUFFT::value)
-                   //  && (USING_CUDA_BACKEND::value == GPU_DATA::value),
-,void>::type
+requires (std::floating_point<T> && hydra::detail::Iterable<Iterable>)
+inline void
 convolute(detail::BackendPolicy<BACKEND> policy, detail::FFTPolicy<T, FFTBackend> fft_policy,
 		  Functor const& functor, Kernel const& kernel,
 		  T min,  T max, Iterable&& output, bool power_up=true ){

--- a/hydra/Decays.h
+++ b/hydra/Decays.h
@@ -39,6 +39,8 @@
 #include <hydra/PhaseSpace.h>
 #include <hydra/detail/FunctorTraits.h>
 #include <hydra/detail/CompositeTraits.h>
+#include <hydra/detail/IteratorConcepts.h>
+#include <hydra/detail/FunctorConcepts.h>
 
 
 namespace hydra {
@@ -239,11 +241,11 @@ public :
 	 }
 
 	 template<typename Functor>
-	 typename std::enable_if<
-	 	 detail::is_hydra_functor<Functor>::value ||
-	 	 detail::is_hydra_lambda<Functor>::value  ||
-	 	 detail::is_hydra_composite_functor<Functor>::value,
-	 	 PhaseSpaceReweight<Functor, Particles...> >::type
+	 requires (
+		detail::HydraCallable<Functor> ||
+		detail::HydraCompositeFunctor<Functor>
+	)
+	 PhaseSpaceReweight<Functor, Particles...>
 	 GetEventWeightFunctor(Functor const& functor) const
 	 {
 		 return  PhaseSpaceReweight<Functor, Particles...>(functor ,fMotherMass, fMasses );
@@ -253,11 +255,11 @@ public :
 	 Unweight(size_t seed=0x180ec6d33cfd0aba);
 
 	 template<typename Functor>
-	 typename std::enable_if<
- 	 detail::is_hydra_functor<Functor>::value ||
- 	 detail::is_hydra_lambda<Functor>::value  ||
- 	 detail::is_hydra_composite_functor<Functor>::value ,
-	 hydra::Range<iterator>>::type
+	 requires (
+		detail::HydraCallable<Functor> ||
+		detail::HydraCompositeFunctor<Functor>
+	)
+	 hydra::Range<iterator>
 	 Unweight( Functor  const& functor, double weight=-1.0, size_t seed=0x39abdc4529b1661c);
 
 	/**
@@ -284,9 +286,9 @@ public :
 	}
 
 	template<typename ...Iterables>
+	requires (hydra::detail::Iterable<Iterables> && ...)
 	auto Meld( Iterables&&... iterable)
-	-> typename std::enable_if< detail::all_true<detail::is_iterable<Iterables>::value...>::value,
-	   decltype(std::declval<storage_type>().meld( std::forward<Iterables>(iterable) ...)) >::type
+	-> decltype(std::declval<storage_type>().meld( std::forward<Iterables>(iterable) ...))
 	{
 		return fDecays.meld(std::forward<Iterables>(iterable)... );
 
@@ -367,7 +369,8 @@ public :
 	}
 
 	template<typename Iterable>
-	typename std::enable_if<detail::is_iterable<Iterable>::value, void>::type
+	requires (hydra::detail::Iterable<Iterable>)
+	void
 	insert(iterator position, Iterable range)
 	{
 		fDecays.insert( position, range);

--- a/hydra/DenseHistogram.h
+++ b/hydra/DenseHistogram.h
@@ -44,6 +44,8 @@
 #include <type_traits>
 #include <utility>
 #include <array>
+#include <hydra/detail/IteratorConcepts.h>
+#include <concepts>
 
 
 namespace hydra {
@@ -51,8 +53,8 @@ namespace hydra {
 /**
  * \ingroup histogram
  */
-template< typename T, std::size_t N, typename BACKEND, typename = typename detail::dimensionality<N>::type,
-	typename = typename std::enable_if<std::is_arithmetic<T>::value, void>::type>
+template< typename T, size_t N, typename BACKEND, typename = typename detail::dimensionality<N>::type>
+requires (std::is_arithmetic<T>::value)
 class DenseHistogram;
 
 /**
@@ -107,7 +109,8 @@ public:
 		fContents.resize(fNBins  +2);
 	}
 
-	template<typename Int, typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	DenseHistogram( std::array<Int, N> grid, std::array<double, N> const& lowerlimits,   std::array<double, N> const& upperlimits):
 					fNBins(1)
 		{
@@ -121,7 +124,8 @@ public:
 			fContents.resize(fNBins +2 );
 		}
 
-	template<typename Int, typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	DenseHistogram( Int (&grid)[N],	double (&lowerlimits)[N], double (&upperlimits)[N] ):
 				fNBins(1)
 		{
@@ -268,8 +272,8 @@ public:
 		return bin;
 	}
 
-	 template<typename Int,
-	 		typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	 template<typename Int>
+	 requires (std::integral<Int>)
 	 inline 	size_t GetBin( Int  (&bins)[N]){
 
 		size_t bin=0;
@@ -279,8 +283,8 @@ public:
 		return bin;
 	}
 
-	 template<typename Int,
-	 		typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	 template<typename Int>
+	 requires (std::integral<Int>)
 	 inline size_t GetBin( std::array<Int,N> const&  bins){
 
 		size_t bin=0;
@@ -300,15 +304,15 @@ public:
 		get_indexes(globalbin, bins);
 	}
 
-	 template<typename Int,
-	 			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	 template<typename Int>
+	 requires (std::integral<Int>)
 	 inline void GetIndexes(size_t globalbin,  Int  (&bins)[N]){
 
 		get_indexes(globalbin, bins);
 	}
 
-	 template<typename Int,
-	 			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	 template<typename Int>
+	 requires (std::integral<Int>)
 	 inline void GetIndexes(size_t globalbin, std::array<Int,N>&  bins){
 
 		get_indexes(globalbin, bins);
@@ -338,8 +342,8 @@ public:
 				std::numeric_limits<double>::max();
 	}
 
-	 template<typename Int,
-	 			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	 template<typename Int>
+	 requires (std::integral<Int>)
 	 inline double GetBinContent( Int (&bins)[N]){
 
 		size_t bin=0;
@@ -351,8 +355,8 @@ public:
 				std::numeric_limits<double>::max();
 	}
 
-	 template<typename Int,
-	 			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	 template<typename Int>
+	 requires (std::integral<Int>)
 	 inline double GetBinContent( std::array<Int, N> const& bins){
 
 		size_t bin=0;
@@ -412,15 +416,18 @@ public:
 
 
     template<size_t M=N>
-    inline typename std::enable_if< M==2, T >::type
+    requires (M==2)
+    inline T
 	Interpolate( std::array<size_t,2> const&  point);
 
     template<size_t M=N>
-    inline typename std::enable_if< M==3, T >::type
+    requires (M==3)
+    inline T
   	Interpolate( std::array<size_t,3> const&  point);
 
     template<size_t M=N>
-    inline typename std::enable_if< M==4, T >::type
+    requires (M==4)
+    inline T
     Interpolate( std::array<size_t,4> const&  point);
 
 	//stl range interface
@@ -467,16 +474,15 @@ public:
 	 Fill(Iterator1 begin, Iterator1 end, Iterator2 wbegin);
 
 	template<typename Iterable>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-	 DenseHistogram<T,N, hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional>&>::type
+	requires (hydra::detail::Iterable<Iterable>)
+	inline DenseHistogram<T,N, hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional>&
 	Fill(Iterable& container){
 		return this->Fill( container.begin(), container.end());
 	}
 
 	template<typename Iterable1, typename Iterable2>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value
-	&&  hydra::detail::is_iterable<Iterable2>::value,
-	 DenseHistogram<T,N, hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional>& >::type
+	requires (hydra::detail::Iterable<Iterable1> && hydra::detail::Iterable<Iterable2>)
+	inline DenseHistogram<T,N, hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional>&
 	Fill(Iterable1& container, Iterable2& wbegin){
 		return this->Fill( container.begin(), container.end(), wbegin.begin());
 	}
@@ -496,11 +502,13 @@ private:
 	//k = i_1*(dim_2*...*dim_n) + i_2*(dim_3*...*dim_n) + ... + i_{n-1}*dim_n + i_n
 
 	template<typename Int,size_t I>
-	typename hydra::thrust::detail::enable_if< (I== N) && std::is_integral<Int>::value, void>::type
+	requires ((I== N) && std::integral<Int>)
+	void
 	get_global_bin(const Int (&)[N], size_t&){ }
 
 	template<typename Int,size_t I=0>
-	typename hydra::thrust::detail::enable_if< (I< N) && std::is_integral<Int>::value, void>::type
+	requires ((I< N) && std::integral<Int>)
+	void
 	get_global_bin(const Int (&indexes)[N], size_t& index)
 	{
 		size_t prod =1;
@@ -512,11 +520,13 @@ private:
 	}
 
 	template<typename Int,size_t I>
-	typename hydra::thrust::detail::enable_if< (I== N) && std::is_integral<Int>::value, void>::type
+	requires ((I== N) && std::integral<Int>)
+	void
 	get_global_bin( std::array<Int,N> const& , size_t&){ }
 
 	template<typename Int,size_t I=0>
-	typename hydra::thrust::detail::enable_if< (I< N) && std::is_integral<Int>::value, void>::type
+	requires ((I< N) && std::integral<Int>)
+	void
 	get_global_bin( std::array<Int,N> const& indexes, size_t& index)
 	{
 		size_t prod =1;
@@ -538,12 +548,14 @@ private:
 	// multiply  std::array elements
 	//----------------------------------------
 	template<size_t I>
-	typename std::enable_if< (I==N), void  >::type
+	requires ((I==N))
+	void
 	multiply( std::array<size_t, N> const&, size_t& )
 	{ }
 
 	template<size_t I=0>
-	typename std::enable_if< (I<N), void  >::type
+	requires ((I<N))
+	void
 	multiply( std::array<size_t, N> const&  obj, size_t& result )
 	{
 		result = I==0? 1.0: result;
@@ -555,12 +567,14 @@ private:
 	// multiply static array elements
 	//----------------------------------------
 	template< size_t I>
-	typename std::enable_if< (I==N), void  >::type
+	requires ((I==N))
+	void
 	multiply( size_t (&)[N] , size_t& )
 	{ }
 
 	template<size_t I=0>
-	typename std::enable_if< (I<N), void  >::type
+	requires ((I<N))
+	void
 	multiply( size_t (&obj)[N], size_t& result )
 	{
 		result = I==0? 1.0: result;
@@ -573,16 +587,16 @@ private:
 	// std::array version
 	//-------------------------
 	//end of recursion
-	template<typename Int, size_t I,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
-	typename std::enable_if< (I==N), void  >::type
+	template<typename Int, size_t I>
+	requires (std::integral<Int> && (I==N))
+	void
 	get_indexes(size_t ,  std::array<Int,N>& )
 	{}
 
 	//begin of the recursion
-	template<typename Int, size_t I=0,
-			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
-	typename std::enable_if< (I<N), void  >::type
+	template<typename Int, size_t I=0>
+	requires (std::integral<Int> && (I<N))
+	void
 	get_indexes(size_t index, std::array<Int,N>& indexes)
 	{
 		size_t factor    =  1;
@@ -596,16 +610,16 @@ private:
 	// static array version
 	//-------------------------
 	//end of recursion
-	template<typename Int, size_t I,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
-	typename std::enable_if< (I==N), void  >::type
+	template<typename Int, size_t I>
+	requires (std::integral<Int> && (I==N))
+	void
 	get_indexes(size_t, Int (&)[N])
 	{}
 
 	//begin of the recursion
-	template<typename Int, size_t I=0,
-			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
-	typename std::enable_if< (I<N), void  >::type
+	template<typename Int, size_t I=0>
+	requires (std::integral<Int> && (I<N))
+	void
 	get_indexes(size_t index, Int (&indexes)[N] )
 	{
 		size_t factor    =  1;
@@ -827,16 +841,15 @@ public:
 	Fill(Iterator1 begin, Iterator1 end, Iterator2 wbegin);
 
 	template<typename Iterable>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-	DenseHistogram<T,1, hydra::detail::BackendPolicy<BACKEND>, detail::unidimensional>& >::type
+	requires (hydra::detail::Iterable<Iterable>)
+	inline DenseHistogram<T,1, hydra::detail::BackendPolicy<BACKEND>, detail::unidimensional>&
 	Fill(Iterable&& container){
 		return this->Fill( std::forward<Iterable>(container).begin(), std::forward<Iterable>(container).end());
 	}
 
 	template<typename Iterable1, typename Iterable2>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value
-	&&  hydra::detail::is_iterable<Iterable2>::value,
-	DenseHistogram<T,1, hydra::detail::BackendPolicy<BACKEND>, detail::unidimensional>& >::type
+	requires (hydra::detail::Iterable<Iterable1> && hydra::detail::Iterable<Iterable2>)
+	inline DenseHistogram<T,1, hydra::detail::BackendPolicy<BACKEND>, detail::unidimensional>&
 	Fill(Iterable1&& container, Iterable2&& wbegin){
 		return this->Fill( container.begin(), container.end(), wbegin.begin());
 	}
@@ -893,8 +906,8 @@ make_dense_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t,
  * @return
  */
 template<typename T, size_t N , hydra::detail::Backend BACKEND, typename Iterable >
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 make_dense_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t, N> const& grid,
 		std::array<double, N> const& lowerlimits,   std::array<double, N> const& upperlimits,	Iterable&& data);
 
@@ -911,9 +924,8 @@ make_dense_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t,
  * @return
  */
 template<typename T, size_t N , hydra::detail::Backend BACKEND, typename Iterable1, typename Iterable2 >
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value &&
-                    hydra::detail::is_iterable<Iterable2>::value,
-DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>>::type
+requires (hydra::detail::Iterable<Iterable1> && hydra::detail::Iterable<Iterable2>)
+inline DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 make_dense_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t, N> const&  grid,
 		std::array<double, N> const& lowerlimits,   std::array<double, N> const& upperlimits,
 		Iterable1&& data, Iterable2&& weight);
@@ -967,8 +979,8 @@ make_dense_histogram( detail::BackendPolicy<BACKEND> backend, size_t nbins,
  * @return
  */
 template<typename T, hydra::detail::Backend BACKEND, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-DenseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline DenseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>
 make_dense_histogram( detail::BackendPolicy<BACKEND> backend, size_t nbins,
 		double lowerlimits,  double upperlimits,	Iterable&& data);
 
@@ -985,9 +997,8 @@ make_dense_histogram( detail::BackendPolicy<BACKEND> backend, size_t nbins,
  * @return
  */
 template<typename T, hydra::detail::Backend BACKEND, typename Iterable1,  typename Iterable2>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value&&
-                                hydra::detail::is_iterable<Iterable2>::value,
-DenseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>>::type
+requires (hydra::detail::Iterable<Iterable1>&& hydra::detail::Iterable<Iterable2>)
+inline DenseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>
 make_dense_histogram( detail::BackendPolicy<BACKEND> backend, size_t nbins,
 		double lowerlimits,  double upperlimits,	Iterable1&& data,	Iterable2&& weight);
 

--- a/hydra/Filter.h
+++ b/hydra/Filter.h
@@ -39,6 +39,7 @@
 
 //thrust
 #include <hydra/detail/external/hydra_thrust/partition.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 //std
 
@@ -55,14 +56,14 @@ namespace hydra {
  * @return
  */
 template<typename Iterable, typename Functor>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-		 hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 filter(Iterable&& container, Functor const& filter);
 
 template<typename Iterable, typename Functor>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-		std::pair<hydra::Range<decltype(std::declval<Iterable>().begin())>,
-		          hydra::Range<decltype(std::declval<Iterable>().begin())>>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline std::pair<hydra::Range<decltype(std::declval<Iterable>().begin())>,
+		          hydra::Range<decltype(std::declval<Iterable>().begin())>>
 segregate(Iterable&& container, Functor const& filter);
 
 

--- a/hydra/Function.h
+++ b/hydra/Function.h
@@ -39,6 +39,7 @@
 #include <hydra/detail/utility/Utility_Tuple.h>
 #include <hydra/detail/FunctorTraits.h>
 #include <hydra/detail/ArgumentTraits.h>
+#include <hydra/detail/TupleConcepts.h>
 #include <hydra/detail/Parameters.h>
 #include <hydra/detail/FunctionArgument.h>
 #include <hydra/detail/GetTupleElement.h>
@@ -165,14 +166,12 @@ public:
 
 
 	template<typename ...T>
-	__hydra_host__  __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_valid_type_pack< argument_type, T...>::value),
-	return_type>::type
+	requires ((!detail::ValidTypePack<argument_type, T...>))
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(T...x)  const
 	{
 		//typename hydra::tuple<T...>::dummy a;
-		HYDRA_STATIC_ASSERT( (!detail::is_valid_type_pack< argument_type, T...>::value), //int(sizeof...(T))==-1,
+		HYDRA_STATIC_ASSERT( (!detail::ValidTypePack<argument_type, T...>), //int(sizeof...(T))==-1,
 				"This Hydra functor can not be called with these arguments.\n"
 				"Possible functions arguments are:\n\n"
 				"1) List of arguments matching or convertible to the functor signature.\n"
@@ -193,10 +192,8 @@ public:
 	 * the lambda signature
 	 */
 	template<typename ...T>
-	__hydra_host__  __hydra_device__
-	inline typename std::enable_if<
-	detail::is_valid_type_pack< argument_type, T...>::value,
-	return_type>::type
+	requires (detail::ValidTypePack<argument_type, T...>)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(T...x)  const
 	{
 		return static_cast<const Functor*>(this)->Evaluate(x...);
@@ -208,12 +205,12 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type< typename std::decay<T>::type >::value )                 &&
-	(!detail::is_tuple_of_function_arguments< typename std::decay<T>::type >::value) &&
-	( hydra::thrust::detail::is_convertible< typename std::decay<T>::type,  argument_type >::value ),
-	return_type >::type
+	requires (
+		( detail::TupleType<T> ) &&
+		(!detail::TupleOfFunctionArguments<T>) &&
+		( hydra::thrust::detail::is_convertible< typename std::decay<T>::type, argument_type >::value )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T x )  const
 	{
 		return  raw_call(x);
@@ -225,11 +222,11 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type<typename std::decay<T>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T>::type >::value),
-	return_type>::type
+	requires (
+		( detail::TupleType<T> ) &&
+		( detail::TupleOfFunctionArguments<T>)
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T x )  const
 	{
 		return  call(x);
@@ -242,13 +239,13 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type<typename std::decay<T1>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type<typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ) ,
-	return_type>::type
+	requires (
+		( detail::TupleType<T1> ) &&
+		( detail::TupleOfFunctionArguments<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T1 x, T2 y )  const
 	{
 		auto z = hydra::thrust::tuple_cat(x, y);
@@ -263,13 +260,13 @@ public:
 	 * the lambda arguments in any order.
 	 */
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_tuple_type< typename std::decay<T1>::type>::value ) &&
-	( detail::is_function_argument< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type< typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ),
-	return_type>::type
+	requires (
+		(!detail::TupleType<T1> ) &&
+		( detail::FunctionArgumentArg<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T1 x, T2 y )  const
 	{
 		auto z = hydra::thrust::tuple_cat(hydra::thrust::make_tuple(x), y);
@@ -283,13 +280,13 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_tuple_type< typename std::decay<T1>::type>::value ) &&
-	( detail::is_function_argument< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type< typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ),
-	return_type>::type
+	requires (
+		(!detail::TupleType<T1> ) &&
+		( detail::FunctionArgumentArg<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(  T2 y, T1 x )  const
 	{
 		auto z = hydra::thrust::tuple_cat(hydra::thrust::make_tuple(x), y);

--- a/hydra/GenzMalikQuadrature.h
+++ b/hydra/GenzMalikQuadrature.h
@@ -63,8 +63,9 @@ class  GenzMalikQuadrature;
  * J. Berntsen, T. O. Espelid, and A. Genz, "An adaptive algorithm for the approximate calculation of multiple integrals," ACM Trans. Math. Soft. 17 (4), 437–451 (1991)
  */
 template<  size_t N, hydra::detail::Backend  BACKEND>
+requires (N>1)
 class  GenzMalikQuadrature<N, hydra::detail::BackendPolicy<BACKEND> >:
-public Integral<typename std::enable_if< (N>1),GenzMalikQuadrature<N, hydra::detail::BackendPolicy<BACKEND>>>::type  >
+public Integral<GenzMalikQuadrature<N, hydra::detail::BackendPolicy<BACKEND>> >
 {
 	typedef  hydra::detail::BackendPolicy<BACKEND> system_type;
 

--- a/hydra/GenzMalikRule.h
+++ b/hydra/GenzMalikRule.h
@@ -69,8 +69,9 @@ class GenzMalikRule;
  *
  */
 template<size_t DIM, hydra::detail::Backend   BACKEND>
+requires (DIM>1)
 class GenzMalikRule<DIM, hydra::detail::BackendPolicy<BACKEND>>:
-           GenzMalikRuleBase<typename std::enable_if< (DIM>1), void >::type >
+           GenzMalikRuleBase<void>
 	{
 
 
@@ -361,13 +362,15 @@ public:
 	private:
 
 		template<size_t N=0>
-		inline   typename std::enable_if< (N==0), GULong64_t>::type twoN()
+		requires ((N==0))
+		inline GULong64_t twoN()
 		{
 			return 1;
 		}
 
 		template<size_t N=0>
-		inline typename std::enable_if< (N>0), GULong64_t>::type twoN()
+		requires ((N>0))
+		inline GULong64_t twoN()
 		{
 			return 2*twoN<N-1>();
 		}

--- a/hydra/Lambda.h
+++ b/hydra/Lambda.h
@@ -33,6 +33,7 @@
 #include <hydra/detail/utility/StaticAssert.h>
 #include <hydra/detail/FunctorTraits.h>
 #include <hydra/detail/ArgumentTraits.h>
+#include <hydra/detail/TupleConcepts.h>
 #include <hydra/detail/Parameters.h>
 #include <hydra/detail/FunctionArgument.h>
 #include <hydra/detail/GetTupleElement.h>
@@ -87,9 +88,8 @@ public:
 
 
    template<typename T= LambdaType>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< std::is_copy_assignable<T>::value,
-	Lambda<T, 0> &>::type
+   requires (std::is_copy_assignable<T>::value)
+   __hydra_host__ __hydra_device__ inline Lambda<T, 0> &
 	operator=(Lambda<T, 0> const & other )
 	{
 		if(this == &other) return *this;
@@ -130,10 +130,8 @@ public:
 
 
 	template<typename ...T>
-	__hydra_host__  __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_valid_type_pack<argument_rvalue_type, T...>::value),
-	return_type>::type
+	requires ((!detail::ValidTypePack<argument_rvalue_type, T...>))
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(T...x)  const
 	{
 		HYDRA_STATIC_ASSERT(int(sizeof...(T))==-1,
@@ -157,10 +155,8 @@ public:
 	 * the lambda signature
 	 */
 	template<typename ...T>
-	__hydra_host__  __hydra_device__
-	inline typename std::enable_if<
-	detail::is_valid_type_pack<argument_rvalue_type, T...>::value,
-	 return_type>::type
+	requires (detail::ValidTypePack<argument_rvalue_type, T...>)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(T...x)  const
 	{
 		return fLambda(x...);
@@ -172,12 +168,12 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type< typename std::decay<T>::type >::value )                 &&
-	(!detail::is_tuple_of_function_arguments< typename std::decay<T>::type >::value) &&
-	( std::is_convertible< typename std::decay<T>::type, argument_rvalue_type >::value ),
-	return_type >::type
+	requires (
+		( detail::TupleType<T> ) &&
+		(!detail::TupleOfFunctionArguments<T>) &&
+		( std::is_convertible< typename std::decay<T>::type, argument_rvalue_type >::value )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T x )  const
 	{
 		return  raw_call(x);
@@ -189,11 +185,11 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type<typename std::decay<T>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T>::type >::value),
-	return_type>::type
+	requires (
+		( detail::TupleType<T> ) &&
+		( detail::TupleOfFunctionArguments<T>)
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T x )  const
 	{
 		return  call(x);
@@ -206,13 +202,12 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type<typename std::decay<T1>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type<typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ) ,
-	return_type>::type
+	requires (( detail::TupleType<T1> ) &&
+	( detail::TupleOfFunctionArguments<T1> ) &&
+	( detail::TupleType<T2> ) &&
+	( detail::TupleOfFunctionArguments<T2> )
+)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T1 x, T2 y )  const
 	{
 		auto z = hydra::thrust::tuple_cat(x, y);
@@ -227,13 +222,13 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_tuple_type< typename std::decay<T1>::type>::value ) &&
-	( detail::is_function_argument< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type< typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ),
-	return_type>::type
+	requires (
+		(!detail::TupleType<T1> ) &&
+		( detail::FunctionArgumentArg<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T1 x, T2 y )  const
 	{
 		auto z = hydra::thrust::tuple_cat(hydra::thrust::make_tuple(x), y);
@@ -247,13 +242,13 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_tuple_type< typename std::decay<T1>::type>::value ) &&
-	( detail::is_function_argument< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type< typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ),
-	return_type>::type
+	requires (
+		(!detail::TupleType<T1> ) &&
+		( detail::FunctionArgumentArg<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(  T2 y, T1 x )  const
 	{
 		auto z = hydra::thrust::tuple_cat(hydra::thrust::make_tuple(x), y);
@@ -340,8 +335,8 @@ public:
 	 * when, if ever, c++20 get cuda support...
 	 */
 	template<typename T=LambdaType>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<std::is_copy_assignable<T>::value, Lambda<T, NPARAM>&>::type
+	requires (std::is_copy_assignable<T>::value)
+	__hydra_host__ __hydra_device__ inline Lambda<T, NPARAM>&
 	operator=(Lambda<T, NPARAM> const & other )
 	{
 		if(this != &other)
@@ -389,10 +384,8 @@ public:
 	}
 
 	template<typename ...T>
-	__hydra_host__  __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_valid_type_pack<argument_type, T...>::value),
-	return_type>::type
+	requires ((!detail::ValidTypePack<argument_type, T...>))
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(T...x)  const
 	{
 		HYDRA_STATIC_ASSERT(int(sizeof...(T))==-1,
@@ -410,45 +403,43 @@ public:
 	}
 
 	template<typename ...T>
-	__hydra_host__  __hydra_device__
-	inline typename  std::enable_if<
-	(detail::is_valid_type_pack<argument_type, T...>::value),
-	return_type>::type
+	requires ((detail::ValidTypePack<argument_type, T...>))
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(T...x)  const
 	{
 		return fLambda(this->GetNumberOfParameters(), this->GetParameters(), x...);
 	}
 
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type< typename std::decay<T>::type >::value )                 &&
-	(!detail::is_tuple_of_function_arguments< typename std::decay<T>::type >::value) &&
-	( std::is_convertible<typename std::decay<T>::type,	argument_rvalue_type>::value ),
-	return_type >::type
+	requires (
+		( detail::TupleType<T> ) &&
+		(!detail::TupleOfFunctionArguments<T>) &&
+		( std::is_convertible<typename std::decay<T>::type, argument_rvalue_type>::value )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T x )  const
 	{
 		return  raw_call(x);
 	}
 
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type<typename std::decay<T>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T>::type >::value),
-	return_type>::type
+	requires (
+		( detail::TupleType<T> ) &&
+		( detail::TupleOfFunctionArguments<T>)
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T x )  const {
 		return  call(x);
 	}
 
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type<typename std::decay<T1>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type<typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ) ,
-	return_type>::type
+	requires (
+		( detail::TupleType<T1> ) &&
+		( detail::TupleOfFunctionArguments<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T1 x, T2 y )  const
 	{
 		auto z = hydra::thrust::tuple_cat(x, y);
@@ -456,13 +447,13 @@ public:
 	}
 
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_tuple_type< typename std::decay<T1>::type>::value ) &&
-	( detail::is_function_argument< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type< typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ),
-	return_type>::type
+	requires (
+		(!detail::TupleType<T1> ) &&
+		( detail::FunctionArgumentArg<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T1 x, T2 y )  const
 	{
 		auto z = hydra::thrust::tuple_cat(hydra::thrust::make_tuple(x), y);
@@ -470,13 +461,13 @@ public:
 	}
 
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_tuple_type< typename std::decay<T1>::type>::value ) &&
-	( detail::is_function_argument< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type< typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ),
-	return_type>::type
+	requires (
+		(!detail::TupleType<T1> ) &&
+		( detail::FunctionArgumentArg<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(  T2 y, T1 x )  const
 	{
 		auto z = hydra::thrust::tuple_cat(hydra::thrust::make_tuple(x), y);
@@ -531,9 +522,8 @@ hydra::Lambda<LambdaType, 0> wrap_lambda(LambdaType const& lambda)
 }
 
 template<typename LambdaType, typename ...T>
-typename std::enable_if<
-detail::all_true<std::is_same<T, hydra::Parameter>::value...>::value,
-hydra::Lambda<LambdaType, sizeof...(T)>>::type
+requires (detail::all_true<std::is_same<T, hydra::Parameter>::value...>::value)
+hydra::Lambda<LambdaType, sizeof...(T)>
 wrap_lambda(LambdaType const& lambda, T const&...parameters)
 {
 	return hydra::Lambda<LambdaType, sizeof...(T)>(lambda, {parameters...});

--- a/hydra/LogLikelihoodFCN.h
+++ b/hydra/LogLikelihoodFCN.h
@@ -20,7 +20,7 @@
  *---------------------------------------------------------------------------*/
 
 /*
- * LogLikelihoodFCN2.h
+ * LogLikelihoodFCN.h
  *
  *  Created on: 13/08/2017
  *      Author: Antonio Augusto Alves Junior
@@ -36,21 +36,9 @@
 #include <hydra/PDFSumNonExtendable.h>
 #include <hydra/detail/HistogramTraits.h>
 #include <hydra/detail/Iterable_traits.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
-
-namespace detail {
-
-template<typename ...Iterators>
-struct are_iterators: std::conditional<sizeof...(Iterators)==0, std::true_type,
-		     detail::all_true<detail::is_iterator<Iterators>::value...> >::type{};
-
-template<typename ...Iterables>
-struct are_iterables: std::conditional<sizeof...(Iterables)==0, std::true_type,
-		     detail::all_true<detail::is_iterable<Iterables>::value...> >::type{};
-
-
-}  // namespace detail
 
 template<typename PDF, typename Iterator, typename... Extensions>
 class LogLikelihoodFCN;
@@ -89,8 +77,8 @@ class LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>, IteratorD, IteratorW...>;
  * @return
  */
 template< typename Functor, typename Integrator,  typename Iterator, typename ...Iterators>
-inline typename std::enable_if< detail::is_iterator<Iterator>::value && detail::are_iterators<Iterators...>::value,
-LogLikelihoodFCN< Pdf<Functor,Integrator>, Iterator , Iterators... > >::type
+requires (detail::Iterator<Iterator> && detail::Iterators<Iterators...>)
+inline LogLikelihoodFCN< Pdf<Functor,Integrator>, Iterator , Iterators... >
 make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Iterator first, Iterator last,  Iterators... weights );
 
 
@@ -104,8 +92,8 @@ make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Iterator first, Iterato
  * @return
  */
 template<typename... Pdfs,  typename Iterator, typename ...Iterators >
-inline typename std::enable_if< detail::is_iterator<Iterator>::value && detail::are_iterators<Iterators...>::value,
-LogLikelihoodFCN< PDFSumExtendable<Pdfs...>, Iterator, Iterators...> >::type
+requires (detail::Iterator<Iterator> && detail::Iterators<Iterators...>)
+inline LogLikelihoodFCN< PDFSumExtendable<Pdfs...>, Iterator, Iterators...>
 make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& functor, Iterator first, Iterator last, Iterators... weights );
 
 
@@ -120,8 +108,8 @@ make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& functor, Iterator first, I
  */
 
 template<typename... Pdfs,  typename Iterator, typename ...Iterators >
-inline typename std::enable_if< hydra::detail::is_iterator<Iterator>::value && detail::are_iterators<Iterators...>::value,
-LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>, Iterator,Iterators...  >>::type
+requires (hydra::detail::Iterator<Iterator> && detail::Iterators<Iterators...>)
+inline LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>, Iterator,Iterators...  >
 make_loglikehood_fcn(PDFSumNonExtendable<Pdfs...>const& pdf, Iterator first, Iterator last, Iterators... weights);
 
 
@@ -137,14 +125,9 @@ make_loglikehood_fcn(PDFSumNonExtendable<Pdfs...>const& pdf, Iterator first, Ite
  * @return
  */
 template< typename Functor, typename Integrator, typename Iterable, typename ...Iterables >
-inline typename std::enable_if< (!detail::is_iterator<Iterable>::value) &&
-								((sizeof...(Iterables)==0) || !detail::are_iterators<Iterables...>::value) &&
-								(!hydra::detail::is_hydra_dense_histogram< typename std::remove_reference<Iterable>::type>::value) &&
-								(!hydra::detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) &&
-								detail::is_iterable<Iterable>::value &&
-								detail::are_iterables<Iterables...>::value,
-LogLikelihoodFCN< Pdf<Functor,Integrator>, decltype(std::declval<Iterable>().begin()),
-                  decltype(std::declval<Iterables >().begin())... >>::type
+requires ((!detail::Iterator<Iterable>) && ((sizeof...(Iterables)==0) || !detail::Iterators<Iterables...>) && (!hydra::detail::is_hydra_dense_histogram< typename std::remove_reference<Iterable>::type>::value) && (!hydra::detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) && hydra::detail::Iterable<Iterable> && detail::Iterables<Iterables...>)
+inline LogLikelihoodFCN< Pdf<Functor,Integrator>, decltype(std::declval<Iterable>().begin()),
+                  decltype(std::declval<Iterables >().begin())... >
 make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Iterable&& points, Iterables&&... weights );
 
 
@@ -158,13 +141,9 @@ make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Iterable&& points, Iter
  * @return
  */
 template<typename ...Pdfs, typename Iterable, typename... Iterables>
-inline typename std::enable_if<   (!detail::is_iterator<Iterable>::value) &&
-                                  ((sizeof...(Iterables)==0) || !detail::are_iterators<Iterables...>::value) &&
-                                  (!hydra::detail::is_hydra_dense_histogram< typename std::remove_reference<Iterable>::type>::value) &&
-		                          (!hydra::detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) &&
-								  detail::is_iterable<Iterable>::value && detail::are_iterables<Iterables...>::value,
-LogLikelihoodFCN<  PDFSumExtendable<Pdfs...>, decltype(std::declval<Iterable>().begin()),
-                     decltype(std::declval<Iterables>().begin())...> >::type
+requires ((!detail::Iterator<Iterable>) && ((sizeof...(Iterables)==0) || !detail::Iterators<Iterables...>) && (!hydra::detail::is_hydra_dense_histogram< typename std::remove_reference<Iterable>::type>::value) && (!hydra::detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) && hydra::detail::Iterable<Iterable> && detail::Iterables<Iterables...>)
+inline LogLikelihoodFCN<  PDFSumExtendable<Pdfs...>, decltype(std::declval<Iterable>().begin()),
+                     decltype(std::declval<Iterables>().begin())...>
 make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& functor, Iterable&& points, Iterables&& ...weights );
 
 
@@ -178,14 +157,9 @@ make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& functor, Iterable&& points
  * @return
  */
 template<typename ...Pdfs, typename Iterable, typename ...Iterables>
-inline typename std::enable_if< (!detail::is_iterator<Iterable>::value) &&
-								((sizeof...(Iterables)==0) || !detail::are_iterators<Iterables...>::value) &&
-								(!hydra::detail::is_hydra_dense_histogram< typename std::remove_reference<Iterable>::type>::value) &&
-								(!hydra::detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) &&
-								hydra::detail::is_iterable<Iterable>::value &&
-								detail::are_iterables<Iterables...>::value,
-LogLikelihoodFCN<  PDFSumNonExtendable<Pdfs...>, decltype(std::declval< Iterable>().begin()),
-                     decltype(std::declval< Iterables>().begin())... > >::type
+requires ((!detail::Iterator<Iterable>) && ((sizeof...(Iterables)==0) || !detail::Iterators<Iterables...>) && (!hydra::detail::is_hydra_dense_histogram< typename std::remove_reference<Iterable>::type>::value) && (!hydra::detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) && hydra::detail::Iterable<Iterable> && detail::Iterables<Iterables...>)
+inline LogLikelihoodFCN<  PDFSumNonExtendable<Pdfs...>, decltype(std::declval< Iterable>().begin()),
+                     decltype(std::declval< Iterables>().begin())... >
 make_loglikehood_fcn(PDFSumNonExtendable<Pdfs...> const& functor, Iterable&& points, Iterables&&... weights );
 
 
@@ -202,11 +176,10 @@ make_loglikehood_fcn(PDFSumNonExtendable<Pdfs...> const& functor, Iterable&& poi
  * @return hydra::LogLikelihoodFCN instance hydra::Pdf<Functor,Integrator>  for .
  */
 template< typename Functor, typename Integrator, typename Histogram>
-inline typename std::enable_if<detail::is_hydra_dense_histogram<Histogram>::value ||
-                               detail::is_hydra_sparse_histogram<Histogram>::value,
-LogLikelihoodFCN< Pdf<Functor,Integrator>,
+requires (detail::is_hydra_dense_histogram<Histogram>::value || detail::is_hydra_sparse_histogram<Histogram>::value)
+inline LogLikelihoodFCN< Pdf<Functor,Integrator>,
 				  decltype(std::declval<const Histogram>().GetBinsCenters().begin()),
-                  decltype( std::declval<const Histogram>().GetBinsContents().begin())>>::type
+                  decltype( std::declval<const Histogram>().GetBinsContents().begin())>
 make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Histogram const& points );
 
 
@@ -218,11 +191,10 @@ make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Histogram const& points
  * @return hydra::LogLikelihoodFCN instance for hydra::PDFSumExtendable<Pdfs...>.
  */
 template<typename ...Pdfs, typename Histogram>
-inline typename std::enable_if<detail::is_hydra_dense_histogram<Histogram>::value ||
-                               detail::is_hydra_sparse_histogram<Histogram>::value,
- LogLikelihoodFCN< PDFSumExtendable<Pdfs...>,
+requires (detail::is_hydra_dense_histogram<Histogram>::value || detail::is_hydra_sparse_histogram<Histogram>::value)
+inline LogLikelihoodFCN< PDFSumExtendable<Pdfs...>,
                      decltype(std::declval<const Histogram&>().GetBinsCenters().begin()),
-                     decltype(std::declval<const Histogram&>().GetBinsContents().begin()) >>::type
+                     decltype(std::declval<const Histogram&>().GetBinsContents().begin()) >
 make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& pdf, Histogram const&  data);
 
 
@@ -234,11 +206,10 @@ make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& pdf, Histogram const&  dat
  * @return hydra::LogLikelihoodFCN instance for hydra::PDFSumNonExtendable<Pdfs...>
  */
 template<typename ...Pdfs, typename Histogram>
-inline typename std::enable_if<detail::is_hydra_dense_histogram<Histogram>::value ||
-                               detail::is_hydra_sparse_histogram<Histogram>::value,
- LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>,
+requires (detail::is_hydra_dense_histogram<Histogram>::value || detail::is_hydra_sparse_histogram<Histogram>::value)
+inline LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>,
                      decltype(std::declval<const Histogram&>().GetBinsCenters().begin()),
-                     decltype(std::declval<const Histogram&>().GetBinsContents().begin()) >>::type
+                     decltype(std::declval<const Histogram&>().GetBinsContents().begin()) >
 make_loglikehood_fcn(PDFSumNonExtendable<Pdfs...> const& pdf, Histogram const&  data);
 
 

--- a/hydra/PhaseSpace.h
+++ b/hydra/PhaseSpace.h
@@ -67,6 +67,7 @@
 #include <vector>
 #include <utility>
 #include <initializer_list>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -196,8 +197,8 @@ public:
 	 * @return A Range object pointing to the @param result container
 	 */
 	template<typename ...FUNCTOR, typename Iterable>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-			 hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+	requires (hydra::detail::Iterable<Iterable>)
+	inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 	Evaluate(Vector4R const& mother, Iterable&& iterable, FUNCTOR const& ...functors);
 
 	/**
@@ -208,9 +209,8 @@ public:
 	 * @return A Range object pointing to the @param result container
 	 */
 	template<typename ...FUNCTOR, typename IterableMother, typename Iterable>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value &&
-	hydra::detail::is_iterable<IterableMother>::value,
-				 hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+	requires (hydra::detail::Iterable<Iterable> && hydra::detail::Iterable<IterableMother>)
+	inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 	Evaluate(IterableMother&& mothers, Iterable&& result, FUNCTOR const& ...functors);
 
 	//--------------------------------------------------------------------
@@ -259,8 +259,8 @@ public:
 	 * @param end Iterator pointing to the end output range.
 	 */
 	template<typename Iterable>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-				 hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+	requires (hydra::detail::Iterable<Iterable>)
+	inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 	Generate(Vector4R const& mother, Iterable&& events);
 
 	/**
@@ -270,9 +270,8 @@ public:
 	 * @param daughters_begin Iterator pointing to the begin of range of daughter particles.
 	 */
 	template<typename IterableMothers, typename Iterable>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value &&
-		hydra::detail::is_iterable<IterableMothers>::value,
-					 hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+	requires (hydra::detail::Iterable<Iterable> && hydra::detail::Iterable<IterableMothers>)
+	inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 	Generate( IterableMothers&& mothers, Iterable&& daughters);
 
 	//--------------------------------------------------------------------------

--- a/hydra/Random.h
+++ b/hydra/Random.h
@@ -43,6 +43,7 @@
 #include <hydra/detail/utility/Utility_Tuple.h>
 #include <hydra/detail/ArgumentTraits.h>
 #include <hydra/detail/PRNGTypedefs.h>
+#include <hydra/detail/RandomConcepts.h>
 
 #include <hydra/Range.h>
 
@@ -551,11 +552,9 @@ sample( Iterable&& output ,
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine = hydra::default_random_engine,  hydra::detail::Backend BACKEND, typename Iterator, typename FUNCTOR >
-typename std::enable_if< hydra::detail::has_rng_formula<FUNCTOR>::value && std::is_convertible<
-decltype(std::declval<RngFormula<FUNCTOR>>().Generate( std::declval<Engine&>(),  std::declval<FUNCTOR const&>())),
-typename hydra::thrust::iterator_traits<Iterator>::value_type
->::value, void>::type
-fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
+requires hydra::detail::HasRngFormula<FUNCTOR> &&
+         hydra::detail::IsRngFormulaConvertible<FUNCTOR, Engine, Iterator>
+void fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
 
 /**
@@ -570,11 +569,9 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine =hydra::default_random_engine, typename Iterator, typename FUNCTOR >
-typename std::enable_if< hydra::detail::has_rng_formula<FUNCTOR>::value && std::is_convertible<
-decltype(std::declval<RngFormula<FUNCTOR>>().Generate( std::declval<Engine&>(),  std::declval<FUNCTOR const&>())),
-typename hydra::thrust::iterator_traits<Iterator>::value_type
->::value, void>::type
-fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
+requires hydra::detail::HasRngFormula<FUNCTOR> &&
+         hydra::detail::IsRngFormulaConvertible<FUNCTOR, Engine, Iterator>
+void fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
 
 /**
  * \ingroup random
@@ -620,8 +617,8 @@ fill_random(Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine = hydra::default_random_engine, hydra::detail::Backend BACKEND, typename Iterator, typename FUNCTOR >
-typename std::enable_if< !hydra::detail::has_rng_formula<FUNCTOR>::value , void>::type
-fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
+requires (!hydra::detail::HasRngFormula<FUNCTOR>)
+void fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
 
 /**
@@ -636,8 +633,8 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine = hydra::default_random_engine, typename Iterator, typename FUNCTOR >
-typename std::enable_if< !hydra::detail::has_rng_formula<FUNCTOR>::value , void>::type
-fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
+requires (!hydra::detail::HasRngFormula<FUNCTOR>)
+void fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
 
 /**
  * \ingroup random
@@ -652,11 +649,9 @@ fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine = hydra::default_random_engine, hydra::detail::Backend BACKEND, typename Iterator, typename FUNCTOR >
-typename std::enable_if< !std::is_convertible<
-decltype(std::declval<RngFormula<FUNCTOR>>().Generate( std::declval<Engine&>(),  std::declval<FUNCTOR const&>())),
-typename std::iterator_traits<Iterator>::value_type
->::value && hydra::detail::has_rng_formula<FUNCTOR>::value, void>::type
-fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
+requires hydra::detail::HasRngFormula<FUNCTOR> &&
+             hydra::detail::NotConvertibleToIteratorValue<FUNCTOR, Engine, Iterator>
+void fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterator begin, Iterator end, FUNCTOR const& funct, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
 
 /**
@@ -671,11 +666,9 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine = hydra::default_random_engine, typename Iterator, typename FUNCTOR >
-typename std::enable_if< !std::is_convertible<
-decltype(std::declval<RngFormula<FUNCTOR>>().Generate( std::declval<Engine&>(),  std::declval<FUNCTOR const&>())),
-typename std::iterator_traits<Iterator>::value_type
->::value && hydra::detail::has_rng_formula<FUNCTOR>::value, void>::type
-fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
+requires hydra::detail::HasRngFormula<FUNCTOR> &&
+             hydra::detail::NotConvertibleToIteratorValue<FUNCTOR, Engine, Iterator>
+void fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
 
 /**
  * \ingroup random

--- a/hydra/Random.h
+++ b/hydra/Random.h
@@ -63,57 +63,6 @@
 
 namespace hydra{
 
-namespace detail {
-
-namespace random {
-
-template<typename T>
-struct is_iterator: std::conditional<
-        !hydra::detail::is_hydra_composite_functor<T>::value &&
-		!hydra::detail::is_hydra_functor<T>::value &&
-		!hydra::detail::is_hydra_lambda<T>::value &&
-		!hydra::detail::is_iterable<T>::value &&
-		 hydra::detail::is_iterator<T>::value,
-         std::true_type,
-         std::false_type >::type {};
-
-template<typename T>
-struct is_iterable: std::conditional<
-        !hydra::detail::is_hydra_composite_functor<T>::value &&
-		!hydra::detail::is_hydra_functor<T>::value &&
-		!hydra::detail::is_hydra_lambda<T>::value  &&
-		 hydra::detail::is_iterable<T>::value &&
-		!hydra::detail::is_iterator<T>::value,
-         std::true_type,
-         std::false_type >::type {};
-
-template<typename T>
-struct is_callable: std::conditional<
-        (hydra::detail::is_hydra_composite_functor<T>::value ||
-         hydra::detail::is_hydra_functor<T>::value ||
-         hydra::detail::is_hydra_lambda<T>::value ) &&
-        !hydra::detail::is_iterable<T>::value &&
-        !hydra::detail::is_iterator<T>::value,
-         std::true_type,
-         std::false_type >::type {};
-
-template< typename Engine, typename Functor, typename Iterable>
-struct is_matching_iterable: std::conditional<
-     hydra::detail::is_iterable<Iterable>::value &&
-    !hydra::detail::is_iterator<Iterable>::value &&
-    (hydra::detail::is_hydra_composite_functor<Functor>::value ||
-     hydra::detail::is_hydra_functor<Functor>::value ||
-     hydra::detail::is_hydra_lambda<Functor>::value  ) &&
-     hydra::detail::has_rng_formula<Functor>::value &&
-     std::is_convertible<
-    decltype(std::declval<RngFormula<Functor>>().Generate( std::declval<Engine&>(), std::declval<Functor const&>())),
-    typename hydra::thrust::iterator_traits<decltype(std::declval<Iterable>().begin())>::value_type>::value,
-    std::true_type,  std::false_type
->::type{};
-}  // namespace random
-
-}  // namespace detail
-
 
 /**
  * \ingroup random
@@ -132,9 +81,8 @@ struct is_matching_iterable: std::conditional<
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename DerivedPolicy, typename IteratorData, typename IteratorWeight>
-typename std::enable_if<
-detail::random::is_iterator<IteratorData>::value && detail::random::is_iterator<IteratorWeight>::value,
-Range<IteratorData> >::type
+requires (detail::random::Iterator<IteratorData> && detail::random::Iterator<IteratorWeight>)
+Range<IteratorData>
 unweight( hydra::thrust::detail::execution_policy_base<DerivedPolicy>  const& policy,
 		IteratorData data_begin, IteratorData data_end, IteratorWeight weights_begin,
 		double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0);
@@ -156,9 +104,8 @@ unweight( hydra::thrust::detail::execution_policy_base<DerivedPolicy>  const& po
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename IteratorData, typename IteratorWeight, hydra::detail::Backend  BACKEND>
-typename std::enable_if<
-detail::random::is_iterator<IteratorData>::value && detail::random::is_iterator<IteratorWeight>::value,
-Range<IteratorData> >::type
+requires (detail::random::Iterator<IteratorData> && detail::random::Iterator<IteratorWeight>)
+Range<IteratorData>
 unweight( detail::BackendPolicy<BACKEND> const& policy, IteratorData data_begin, IteratorData data_end, IteratorWeight weights_begin,
 		double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0);
 
@@ -178,10 +125,8 @@ unweight( detail::BackendPolicy<BACKEND> const& policy, IteratorData data_begin,
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename IteratorData, typename IteratorWeight>
-typename std::enable_if<
-	detail::random::is_iterator<IteratorData>::value && detail::random::is_iterator<IteratorWeight>::value,
-	Range<IteratorData>
->::type
+requires (detail::random::Iterator<IteratorData> && detail::random::Iterator<IteratorWeight>)
+Range<IteratorData>
 unweight(IteratorData data_begin, IteratorData data_end , IteratorData weights_begin,
 		double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0);
 
@@ -201,9 +146,8 @@ unweight(IteratorData data_begin, IteratorData data_end , IteratorData weights_b
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename IterableData, typename IterableWeight, hydra::detail::Backend BACKEND>
-typename std::enable_if<
-detail::random::is_iterable<IterableData>::value && detail::random::is_iterable<IterableWeight>::value,
-Range< decltype(std::declval<IterableData>().begin())> >::type
+requires (detail::random::Iterable<IterableData> && detail::random::Iterable<IterableWeight>)
+Range< decltype(std::declval<IterableData>().begin())>
 unweight( hydra::detail::BackendPolicy<BACKEND> const& policy,  IterableData&& data, IterableWeight&& weights,
 		double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0);
 
@@ -222,10 +166,8 @@ unweight( hydra::detail::BackendPolicy<BACKEND> const& policy,  IterableData&& d
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename IterableData, typename IterableWeight>
-typename std::enable_if<
-	detail::random::is_iterable<IterableData>::value && detail::random::is_iterable<IterableWeight>::value,
-	Range< decltype(std::declval<IterableData>().begin())>
->::type
+requires (detail::random::Iterable<IterableData> && detail::random::Iterable<IterableWeight>)
+Range< decltype(std::declval<IterableData>().begin())>
 unweight( IterableData data, IterableWeight weights,
 		double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0 );
 
@@ -245,10 +187,8 @@ unweight( IterableData data, IterableWeight weights,
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterator, typename DerivedPolicy>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-	Range<Iterator>
->::type
+requires (detail::random::Callable<Functor> && detail::random::Iterator<Iterator>)
+Range<Iterator>
 unweight( hydra::thrust::detail::execution_policy_base<DerivedPolicy> const& policy,
 	    	Iterator begin, Iterator end, Functor const& functor,
 			double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0 );
@@ -269,10 +209,8 @@ unweight( hydra::thrust::detail::execution_policy_base<DerivedPolicy> const& pol
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterator, hydra::detail::Backend  BACKEND>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-	Range<Iterator>
->::type
+requires (detail::random::Callable<Functor> && detail::random::Iterator<Iterator>)
+Range<Iterator>
 unweight( hydra::detail::BackendPolicy<BACKEND> const& policy, Iterator begin, Iterator end, Functor const& functor,
 		double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0 );
 
@@ -290,10 +228,8 @@ unweight( hydra::detail::BackendPolicy<BACKEND> const& policy, Iterator begin, I
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterator>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-	Range<Iterator>
->::type
+requires (detail::random::Callable<Functor> && detail::random::Iterator<Iterator>)
+Range<Iterator>
 unweight( Iterator begin, Iterator end, Functor const& functor,
 		double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0 );
 
@@ -310,10 +246,8 @@ unweight( Iterator begin, Iterator end, Functor const& functor,
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterable, hydra::detail::Backend  BACKEND>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterable<Iterable>::value ,
-	Range< decltype(std::declval<Iterable>().begin())>
->::type
+requires (detail::random::Callable<Functor> && detail::random::Iterable<Iterable>)
+Range< decltype(std::declval<Iterable>().begin())>
 unweight( hydra::detail::BackendPolicy<BACKEND> const& policy,
 		Iterable&& iterable, Functor const& functor,
 		double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0  );
@@ -331,9 +265,8 @@ unweight( hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @return hydra::Range object pointing unweighted sample.
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterable>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterable<Iterable>::value ,
-Range< decltype(std::declval<Iterable>().begin())>>::type
+requires (detail::random::Callable<Functor> && detail::random::Iterable<Iterable>)
+Range< decltype(std::declval<Iterable>().begin())>
 unweight( Iterable&& iterable, Functor const& functor,
 		double max_pdf=-1.0, size_t rng_seed=0x8ec74d321e6b5a27, size_t rng_jump=0 );
 
@@ -352,9 +285,8 @@ unweight( Iterable&& iterable, Functor const& functor,
  * @return range with the generated values
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterator, hydra::detail::Backend  BACKEND>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-Range<Iterator> >::type
+requires (detail::random::Callable<Functor> && detail::random::Iterator<Iterator>)
+Range<Iterator>
 sample(hydra::detail::BackendPolicy<BACKEND> const& policy,
 		Iterator begin, Iterator end, double min, double max,
 		Functor const& functor, size_t seed=0xb56c4feeef1b, size_t rng_jump=0 );
@@ -373,9 +305,8 @@ sample(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @return range with the generated values
  */
 template<typename RNG=default_random_engine, typename DerivedPolicy, typename Functor, typename Iterator>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-Range<Iterator> >::type
+requires (detail::random::Callable<Functor> && detail::random::Iterator<Iterator>)
+Range<Iterator>
 sample(hydra::thrust::detail::execution_policy_base<DerivedPolicy> const& policy,
 		Iterator begin, Iterator end, double min, double max,
 		Functor const& functor, size_t seed=0xb56c4feeef1b, size_t rng_jump=0 );
@@ -393,9 +324,8 @@ sample(hydra::thrust::detail::execution_policy_base<DerivedPolicy> const& policy
  * @return range with the generated values
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterator>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-Range<Iterator> >::type
+requires (detail::random::Callable<Functor> && detail::random::Iterator<Iterator>)
+Range<Iterator>
 sample(Iterator begin, Iterator end , double min, double max,
 		Functor const& functor, size_t seed=0xb56c4feeef1b, size_t rng_jump=0 );
 
@@ -411,9 +341,8 @@ sample(Iterator begin, Iterator end , double min, double max,
  * @return range with the generated values
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterable>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterable<Iterable>::value ,
-Range< decltype(std::declval<Iterable>().begin())>>::type
+requires (detail::random::Callable<Functor> && detail::random::Iterable<Iterable>)
+Range< decltype(std::declval<Iterable>().begin())>
 sample(Iterable&& output, double min, double max,
 		Functor const& functor, size_t seed=0xb56c4feeef1b, size_t rng_jump=0 );
 
@@ -430,9 +359,8 @@ sample(Iterable&& output, double min, double max,
  * @return range with the generated values
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterator, size_t N >
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-Range<Iterator> >::type
+requires (detail::random::Callable<Functor> && detail::random::Iterator<Iterator>)
+Range<Iterator>
 sample(Iterator begin, Iterator end , std::array<double,N>const& min, std::array<double,N>const& max,
 		Functor const& functor, size_t seed=0xb56c4feeef1b, size_t rng_jump=0 );
 
@@ -449,11 +377,12 @@ sample(Iterator begin, Iterator end , std::array<double,N>const& min, std::array
  * @return range with the generated values
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterator>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value  &&
-detail::random::is_iterator<Iterator>::value &&
-detail::is_tuple_type< decltype(*std::declval<Iterator>())>::value,
-Range<Iterator> >::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator> &&
+	detail::is_tuple_type< decltype(*std::declval<Iterator>())>::value
+)
+Range<Iterator>
 sample(Iterator begin, Iterator end ,
 		typename Functor::argument_type const& min, typename Functor::argument_type const& max,
 		Functor const& functor, size_t seed=0xb56c4feeef1b, size_t rng_jump=0 );
@@ -471,9 +400,8 @@ sample(Iterator begin, Iterator end ,
  * @param functor distribution to be sampled
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterator, hydra::detail::Backend  BACKEND, size_t N >
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-Range<Iterator> >::type
+requires (detail::random::Callable<Functor> && detail::random::Iterator<Iterator>)
+Range<Iterator>
 sample(hydra::detail::BackendPolicy<BACKEND> const& policy,
 		Iterator begin, Iterator end ,
 		std::array<double,N>const& min,	std::array<double,N>const& max,
@@ -491,9 +419,8 @@ sample(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param functor distribution to be sampled
  */
 template<typename RNG=default_random_engine, typename DerivedPolicy, typename Functor, typename Iterator, size_t N >
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-Range<Iterator> >::type
+requires (detail::random::Callable<Functor> && detail::random::Iterator<Iterator>)
+Range<Iterator>
 sample(hydra::thrust::detail::execution_policy_base<DerivedPolicy>  const& policy,
 		Iterator begin, Iterator end ,
 		std::array<double,N>const& min,	std::array<double,N>const& max,
@@ -511,9 +438,8 @@ sample(hydra::thrust::detail::execution_policy_base<DerivedPolicy>  const& polic
  * @return output range with the generated values
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterable, size_t N >
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterable<Iterable>::value ,
-Range< decltype(std::declval<Iterable>().begin())>>::type
+requires (detail::random::Callable<Functor> && detail::random::Iterable<Iterable>)
+Range< decltype(std::declval<Iterable>().begin())>
 sample( Iterable&& output ,
 		std::array<double,N>const& min, std::array<double,N>const& max,
 		Functor const& functor, size_t seed=0xb56c4feeef1b, size_t rng_jump=0 );
@@ -530,11 +456,12 @@ sample( Iterable&& output ,
  * @return output range with the generated values
  */
 template<typename RNG=default_random_engine, typename Functor, typename Iterable>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value  &&
-detail::random::is_iterable<Iterable>::value &&
-detail::is_tuple_type< decltype(*std::declval<Iterable>().begin())>::value ,
-Range< decltype(std::declval<Iterable>().begin())>>::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterable<Iterable> &&
+	detail::is_tuple_type< decltype(*std::declval<Iterable>().begin())>::value
+)
+Range< decltype(std::declval<Iterable>().begin())>
 sample( Iterable&& output ,
 		typename Functor::argument_type const& min,typename Functor::argument_type  const& max,
 		Functor const& functor, size_t seed=0xb56c4feeef1b, size_t rng_jump=0 );
@@ -585,7 +512,8 @@ void fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t se
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine = hydra::default_random_engine, hydra::detail::Backend BACKEND, typename Iterable, typename FUNCTOR >
-typename std::enable_if< detail::random::is_matching_iterable<Engine, FUNCTOR, Iterable>::value, void>::type
+requires (detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+void
 fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
 
@@ -600,8 +528,8 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine = hydra::default_random_engine, typename Iterable, typename FUNCTOR >
-typename std::enable_if< detail::random::is_matching_iterable<Engine, FUNCTOR, Iterable>::value,
-void>::type
+requires (detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+void
 fill_random(Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
 
 /**
@@ -682,7 +610,8 @@ void fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t se
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine = hydra::default_random_engine, hydra::detail::Backend BACKEND, typename Iterable, typename FUNCTOR >
-typename std::enable_if< !(detail::random::is_matching_iterable<Engine, FUNCTOR, Iterable>::value), void>::type
+requires (!(detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>))
+void
 fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
 
@@ -697,9 +626,9 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param rng_jump sequence offset for the underlying pseudo-random number generator
  */
 template< typename Engine = hydra::default_random_engine, typename Iterable, typename FUNCTOR >
-typename std::enable_if<!(detail::random::is_matching_iterable<Engine, FUNCTOR, Iterable>::value),void>::type
+requires (!(detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>))
+void
 fill_random(Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2, size_t rng_jump=0 );
-
 
 
 }

--- a/hydra/RandomFill.h
+++ b/hydra/RandomFill.h
@@ -50,6 +50,8 @@
 #include <hydra/detail/external/hydra_thrust/system/detail/generic/select_system.h>
 #include <array>
 #include <utility>
+#include <hydra/detail/IteratorConcepts.h>
+#include <hydra/detail/RandomConcepts.h>
 
 
 
@@ -66,10 +68,9 @@ namespace hydra{
  * @param functor distribution to be sampled
  */
 template< typename Engine = hydra::default_random_engine,  hydra::detail::Backend BACKEND, typename Iterator, typename FUNCTOR >
-typename std::enable_if< hydra::detail::has_rng_formula<FUNCTOR>::value && std::is_convertible<
-decltype(std::declval<RngFormula<FUNCTOR>>().Generate( std::declval<Engine&>(),  std::declval<FUNCTOR const&>())),
-typename hydra::thrust::iterator_traits<Iterator>::value_type
->::value, void>::type
+requires hydra::detail::HasRngFormula<FUNCTOR> &&
+         hydra::detail::IsRngFormulaConvertible<FUNCTOR, Engine, Iterator>
+void
 fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2);
 
@@ -86,10 +87,9 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param functor distribution to be sampled
  */
 template< typename Engine =hydra::default_random_engine, typename Iterator, typename FUNCTOR >
-typename std::enable_if< hydra::detail::has_rng_formula<FUNCTOR>::value && std::is_convertible<
-decltype(std::declval<RngFormula<FUNCTOR>>().Generate( std::declval<Engine&>(),  std::declval<FUNCTOR const&>())),
-typename hydra::thrust::iterator_traits<Iterator>::value_type
->::value, void>::type
+requires hydra::detail::HasRngFormula<FUNCTOR> &&
+         hydra::detail::IsRngFormulaConvertible<FUNCTOR, Engine, Iterator>
+void
 fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2);
 
 
@@ -105,9 +105,8 @@ fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x
  * @param functor distribution to be sampled
  */
 template< typename Engine = hydra::default_random_engine, hydra::detail::Backend BACKEND, typename Iterable, typename FUNCTOR >
-typename std::enable_if< hydra::detail::is_iterable<Iterable>::value && std::is_convertible<
-decltype(*std::declval<Iterable>().begin()), typename FUNCTOR::return_type
->::value, void>::type
+requires (detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+void
 fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2);
 
@@ -123,9 +122,8 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param functor distribution to be sampled
  */
 template< typename Engine = hydra::default_random_engine, typename Iterable, typename FUNCTOR >
-typename std::enable_if< hydra::detail::is_iterable<Iterable>::value && std::is_convertible<
-decltype(*std::declval<Iterable>().begin()), typename FUNCTOR::return_type
->::value, void>::type
+requires (detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+void
 fill_random(Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2);
 
 
@@ -142,7 +140,8 @@ fill_random(Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf
  * @param functor distribution to be sampled
  */
 template< typename Engine = hydra::default_random_engine, hydra::detail::Backend BACKEND, typename Iterator, typename FUNCTOR >
-typename std::enable_if< !hydra::detail::has_rng_formula<FUNCTOR>::value , void>::type
+requires (!hydra::detail::HasRngFormula<FUNCTOR>)
+void
 fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2);
 
@@ -158,7 +157,8 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param functor distribution to be sampled
  */
 template< typename Engine = hydra::default_random_engine, typename Iterator, typename FUNCTOR >
-typename std::enable_if< !hydra::detail::has_rng_formula<FUNCTOR>::value , void>::type
+requires (!hydra::detail::HasRngFormula<FUNCTOR>)
+void
 fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2);
 
 
@@ -174,10 +174,9 @@ fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x
  * @param functor distribution to be sampled
  */
 template< typename Engine = hydra::default_random_engine, hydra::detail::Backend BACKEND, typename Iterator, typename FUNCTOR >
-typename std::enable_if< !std::is_convertible<
-decltype(std::declval<RngFormula<FUNCTOR>>().Generate( std::declval<Engine&>(),  std::declval<FUNCTOR const&>())),
-typename std::iterator_traits<Iterator>::value_type
->::value && hydra::detail::has_rng_formula<FUNCTOR>::value, void>::type
+requires hydra::detail::HasRngFormula<FUNCTOR> &&
+         hydra::detail::NotConvertibleToIteratorValue<FUNCTOR, Engine, Iterator>
+void
 fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterator begin, Iterator end, FUNCTOR const& funct, size_t seed=0x254a0afcf7da74a2);
 
@@ -193,10 +192,9 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param functor distribution to be sampled
  */
 template< typename Engine = hydra::default_random_engine, typename Iterator, typename FUNCTOR >
-typename std::enable_if< !std::is_convertible<
-decltype(std::declval<RngFormula<FUNCTOR>>().Generate( std::declval<Engine&>(),  std::declval<FUNCTOR const&>())),
-typename std::iterator_traits<Iterator>::value_type
->::value && hydra::detail::has_rng_formula<FUNCTOR>::value, void>::type
+requires hydra::detail::HasRngFormula<FUNCTOR> &&
+         hydra::detail::NotConvertibleToIteratorValue<FUNCTOR, Engine, Iterator>
+void
 fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2);
 
 
@@ -212,9 +210,8 @@ fill_random(Iterator begin, Iterator end, FUNCTOR const& functor, size_t seed=0x
  * @param functor distribution to be sampled
  */
 template< typename Engine = hydra::default_random_engine, hydra::detail::Backend BACKEND, typename Iterable, typename FUNCTOR >
-typename std::enable_if< !hydra::detail::is_iterable<Iterable>::value || !std::is_convertible<
-decltype(*std::declval<Iterable>().begin()), typename FUNCTOR::return_type
->::value, void>::type
+requires (!detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+void
 fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
             Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2);
 
@@ -229,9 +226,8 @@ fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
  * @param functor distribution to be sampled
  */
 template< typename Engine = hydra::default_random_engine, typename Iterable, typename FUNCTOR >
-typename std::enable_if< !hydra::detail::is_iterable<Iterable>::value || !std::is_convertible<
-decltype(*std::declval<Iterable>().begin()), typename FUNCTOR::return_type
->::value, void>::type
+requires (!detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+void
 fill_random(Iterable&& iterable, FUNCTOR const& functor, size_t seed=0x254a0afcf7da74a2);
 
 

--- a/hydra/SPlot.h
+++ b/hydra/SPlot.h
@@ -54,6 +54,7 @@
 
 #include <initializer_list>
 #include <utility>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -364,9 +365,9 @@ private:
  * @param last iterator pointing to end of the data  range.
  * @return
  */
-template <typename Iterator, typename PDF1,  typename PDF2, typename ...PDFs>
-typename std::enable_if< detail::is_iterator<Iterator>::value,
-                 SPlot<Iterator, PDF1, PDF2, PDFs...> >::type
+template<typename Iterator, typename PDF1,  typename PDF2, typename ...PDFs>
+requires (detail::Iterator<Iterator>)
+SPlot<Iterator, PDF1, PDF2, PDFs...>
 make_splot(PDFSumExtendable<PDF1, PDF2, PDFs...> const& pdf, Iterator first, Iterator last) {
 
  return 	SPlot<Iterator, PDF1, PDF2, PDFs...>(pdf, first,last);
@@ -379,9 +380,9 @@ make_splot(PDFSumExtendable<PDF1, PDF2, PDFs...> const& pdf, Iterator first, Ite
  * @param data iterable representing the data-range
  * @return
  */
-template <typename Iterable, typename PDF1,  typename PDF2, typename ...PDFs>
-typename std::enable_if< detail::is_iterable<Iterable>::value,
-                  SPlot< decltype(std::declval<Iterable>().begin()), PDF1, PDF2, PDFs...> >::type
+template<typename Iterable, typename PDF1,  typename PDF2, typename ...PDFs>
+requires (detail::Iterable<Iterable>)
+SPlot< decltype(std::declval<Iterable>().begin()), PDF1, PDF2, PDFs...>
 make_splot(PDFSumExtendable<PDF1, PDF2, PDFs...> const& pdf, Iterable&& data){
 
  return 	SPlot< decltype(std::declval<Iterable>().begin()) ,

--- a/hydra/SparseHistogram.h
+++ b/hydra/SparseHistogram.h
@@ -45,14 +45,16 @@
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
 #include <hydra/detail/external/hydra_thrust/iterator/zip_iterator.h>
 #include <hydra/detail/external/hydra_thrust/find.h>
+#include <hydra/detail/IteratorConcepts.h>
+#include <concepts>
 
 namespace hydra {
 
 /**
  * \ingroup histogram
  */
-template<typename T, size_t N,  typename BACKEND, typename = typename detail::dimensionality<N>::type,
-	typename = typename std::enable_if<std::is_arithmetic<T>::value, void>::type>
+template<typename T, size_t N,  typename BACKEND, typename = typename detail::dimensionality<N>::type>
+requires (std::is_arithmetic<T>::value)
 class SparseHistogram;
 
 /**
@@ -118,7 +120,8 @@ public:
 
 	}
 
-	template<typename Int, typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	SparseHistogram( std::array<Int , N> const& grid,
 			std::array<double, N> const& lowerlimits,   std::array<double, N> const& upperlimits):
 				fNBins(1)
@@ -132,7 +135,8 @@ public:
 
 	}
 
-	template<typename Int, typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	SparseHistogram( Int (&grid)[N],
 			T (&lowerlimits)[N],   T (&upperlimits)[N] ):
 				fNBins(1)
@@ -245,8 +249,8 @@ public:
 		return fNBins;
 	}
 
-	template<typename Int,
-			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline 	size_t GetBin( Int  (&bins)[N]){
 
 		size_t bin=0;
@@ -266,8 +270,8 @@ public:
 	}
 
 
-	template<typename Int,
-		typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline size_t GetBin( std::array<Int,N> const&  bins){
 
 		size_t bin=0;
@@ -277,22 +281,22 @@ public:
 		return bin;
 	}
 
-	template<typename Int,
-			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline void GetIndexes(size_t globalbin,  Int  (&bins)[N]){
 
 		get_indexes(globalbin, bins);
 	}
 
-	template<typename Int,
-				typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline void GetIndexes(size_t globalbin, std::array<Int,N>&  bins){
 
 		get_indexes(globalbin, bins);
 	}
 
-	template<typename Int,
-				typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline double GetBinContent( Int  (&bins)[N]){
 
 		size_t bin=0;
@@ -319,8 +323,8 @@ public:
 	}
 
 
-	template<typename Int,
-					typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline double GetBinContent(std::array<Int, N> const& bins){
 
 			size_t bin=0;
@@ -369,15 +373,18 @@ public:
 	}
 
 	template<size_t M=N>
-	inline typename std::enable_if< M==2, T >::type
+	requires (M==2)
+	inline T
 	Interpolate( std::array<size_t,2> const&  point);
 
 	template<size_t M=N>
-	inline typename std::enable_if< M==3, T >::type
+	requires (M==3)
+	inline T
 	Interpolate( std::array<size_t,3> const&  point);
 
 	template<size_t M=N>
-	inline typename std::enable_if< M==4, T >::type
+	requires (M==4)
+	inline T
 	Interpolate( std::array<size_t,4> const&  point);
 
 
@@ -430,17 +437,16 @@ public:
 
 
 	template<typename Iterable>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-	SparseHistogram<T, N, detail::BackendPolicy<BACKEND>, detail::multidimensional>& >::type
+	requires (hydra::detail::Iterable<Iterable>)
+	inline SparseHistogram<T, N, detail::BackendPolicy<BACKEND>, detail::multidimensional>&
 	Fill(Iterable&& container){
 		return this->Fill( std::forward<Iterable>(container).begin(),
 				std::forward<Iterable>(container).end());
 	}
 
 	template<typename Iterable1, typename Iterable2>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value
-	&&  hydra::detail::is_iterable<Iterable2>::value,
-	SparseHistogram<T, N, detail::BackendPolicy<BACKEND>, detail::multidimensional>& >::type
+	requires (hydra::detail::Iterable<Iterable1> && hydra::detail::Iterable<Iterable2>)
+	inline SparseHistogram<T, N, detail::BackendPolicy<BACKEND>, detail::multidimensional>&
 	Fill(Iterable1&& container, Iterable2&& wbegin){
 		return this->Fill( std::forward<Iterable1>(container).begin(),
 				std::forward<Iterable1>(container).end(), std::forward<Iterable2>(wbegin).begin());
@@ -462,11 +468,13 @@ private:
 	//k = i_1*(dim_2*...*dim_n) + i_2*(dim_3*...*dim_n) + ... + i_{n-1}*dim_n + i_n
 
 	template<typename Int,size_t I>
-	typename hydra::thrust::detail::enable_if< (I== N) && std::is_integral<Int>::value, void>::type
+	requires ((I== N) && std::integral<Int>)
+	void
 	get_global_bin(const Int (&)[N], size_t& ){ }
 
 	template<typename Int,size_t I=0>
-	typename hydra::thrust::detail::enable_if< (I< N) && std::is_integral<Int>::value, void>::type
+	requires ((I< N) && std::integral<Int>)
+	void
 	get_global_bin(const Int (&indexes)[N], size_t& index)
 	{
 		size_t prod =1;
@@ -478,11 +486,13 @@ private:
 	}
 
 	template<typename Int,size_t I>
-	typename hydra::thrust::detail::enable_if< (I== N) && std::is_integral<Int>::value, void>::type
+	requires ((I== N) && std::integral<Int>)
+	void
 	get_global_bin( std::array<Int,N> const& , size_t& ){ }
 
 	template<typename Int,size_t I=0>
-	typename hydra::thrust::detail::enable_if< (I< N) && std::is_integral<Int>::value, void>::type
+	requires ((I< N) && std::integral<Int>)
+	void
 	get_global_bin( std::array<Int,N> const& indexes, size_t& index)
 	{
 		size_t prod =1;
@@ -503,12 +513,14 @@ private:
 	// multiply  std::array elements
 	//----------------------------------------
 	template<size_t I>
-	typename std::enable_if< (I==N), void  >::type
+	requires ((I==N))
+	void
 	multiply( std::array<size_t, N> const& , size_t&  )
 	{ }
 
 	template<size_t I=0>
-	typename std::enable_if< (I<N), void  >::type
+	requires ((I<N))
+	void
 	multiply( std::array<size_t, N> const&  obj, size_t& result )
 	{
 		result = I==0? 1.0: result;
@@ -520,12 +532,14 @@ private:
 	// multiply static array elements
 	//----------------------------------------
 	template< size_t I>
-	typename std::enable_if< (I==N), void  >::type
+	requires ((I==N))
+	void
 	multiply( size_t (&)[N] , size_t&  )
 	{ }
 
 	template<size_t I=0>
-	typename std::enable_if< (I<N), void  >::type
+	requires ((I<N))
+	void
 	multiply( size_t (&obj)[N], size_t& result )
 	{
 		result = I==0? 1.0: result;
@@ -538,16 +552,16 @@ private:
 	// std::array version
 	//-------------------------
 	//end of recursion
-	template<typename Int, size_t I,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
-	typename std::enable_if< (I==N), void  >::type
+	template<typename Int, size_t I>
+	requires (std::integral<Int> && (I==N))
+	void
 	get_indexes(size_t,  std::array<Int,N>& )
 	{}
 
 	//begin of the recursion
-	template<typename Int, size_t I=0,
-			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
-	typename std::enable_if< (I<N), void  >::type
+	template<typename Int, size_t I=0>
+	requires (std::integral<Int> && (I<N))
+	void
 	get_indexes(size_t index, std::array<Int,N>& indexes)
 	{
 		size_t factor    =  1;
@@ -561,16 +575,16 @@ private:
 	// static array version
 	//-------------------------
 	//end of recursion
-	template<typename Int, size_t I,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
-	typename std::enable_if< (I==N), void  >::type
+	template<typename Int, size_t I>
+	requires (std::integral<Int> && (I==N))
+	void
 	get_indexes(size_t , Int (&)[N])
 	{}
 
 	//begin of the recursion
-	template<typename Int, size_t I=0,
-			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
-	typename std::enable_if< (I<N), void  >::type
+	template<typename Int, size_t I=0>
+	requires (std::integral<Int> && (I<N))
+	void
 	get_indexes(size_t index, Int (&indexes)[N] )
 	{
 		size_t factor    =  1;
@@ -786,17 +800,16 @@ public:
 
 
 	template<typename Iterable>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-	SparseHistogram<T,1, detail::BackendPolicy<BACKEND>,detail::unidimensional >& >::type
+	requires (hydra::detail::Iterable<Iterable>)
+	inline SparseHistogram<T,1, detail::BackendPolicy<BACKEND>,detail::unidimensional >&
 	Fill(Iterable&& container){
 		return this->Fill( std::forward<Iterable>(container).begin(),
 				std::forward<Iterable>(container).end());
 	}
 
 	template<typename Iterable1, typename Iterable2>
-	inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value
-	&&  hydra::detail::is_iterable<Iterable2>::value,
-	SparseHistogram<T,1, detail::BackendPolicy<BACKEND>,detail::unidimensional >& >::type
+	requires (hydra::detail::Iterable<Iterable1> && hydra::detail::Iterable<Iterable2>)
+	inline SparseHistogram<T,1, detail::BackendPolicy<BACKEND>,detail::unidimensional >&
 	Fill(Iterable1&& container, Iterable2&& wbegin){
 		return this->Fill( std::forward<Iterable1>(container).begin(),
 				std::forward<Iterable1>(container).end(), std::forward<Iterable2>(wbegin).begin());
@@ -874,8 +887,8 @@ make_sparse_histogram( detail::BackendPolicy<BACKEND>, std::array<size_t, N> gri
  * @return
  */
 template< typename T, size_t N , hydra::detail::Backend BACKEND, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t, N>const& grid,
 		std::array<double, N>const&lowerlimits,   std::array<double, N>const& upperlimits,	Iterable&& data);
 
@@ -893,9 +906,8 @@ make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t
  * @return
  */
 template< typename T, size_t N , hydra::detail::Backend BACKEND, typename Iterable1,typename Iterable2 >
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value&&
-hydra::detail::is_iterable<Iterable2>::value,
-SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>>::type
+requires (hydra::detail::Iterable<Iterable1>&& hydra::detail::Iterable<Iterable2>)
+inline SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t, N>const& grid,
 		std::array<double, N>const&lowerlimits,   std::array<double, N>const& upperlimits,
 		Iterable1&& data, Iterable2&& weights);
@@ -949,8 +961,8 @@ make_sparse_histogram( detail::BackendPolicy<BACKEND>, size_t nbins, double lowe
  * @return
  */
 template< typename T, hydra::detail::Backend BACKEND, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-SparseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline SparseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>
 make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, size_t nbins,
 		double lowerlimit, double upperlimit,	Iterable&& data);
 
@@ -967,9 +979,8 @@ make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, size_t nbins,
  * @return
  */
 template< typename T, hydra::detail::Backend BACKEND, typename Iterable1,typename Iterable2 >
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value&&
-hydra::detail::is_iterable<Iterable2>::value,
-SparseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>>::type
+requires (hydra::detail::Iterable<Iterable1>&& hydra::detail::Iterable<Iterable2>)
+inline SparseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>
 make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, size_t nbins,
 		double lowerlimit, double upperlimit,	Iterable1&& data, Iterable2&& weights);
 

--- a/hydra/Spline.h
+++ b/hydra/Spline.h
@@ -46,6 +46,7 @@
 #include <math.h>
 #include <algorithm>
 #include <type_traits>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -63,12 +64,12 @@ namespace hydra {
  * @return Interpolated value
  */
 template<typename Iterator1, typename Iterator2, typename Type>
-__hydra_host__ __hydra_device__
-inline typename  std::enable_if<
-                    std::is_convertible<typename hydra::thrust::iterator_traits<Iterator1>::value_type, double >::value &&
-                    std::is_convertible<typename hydra::thrust::iterator_traits<Iterator2>::value_type, double >::value &&
-					std::is_convertible<Type, double >::value ,
-                    Type >::type
+requires (
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<Iterator1>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<Iterator2>::value_type, double > &&
+	std::is_convertible_v<Type, double >
+)
+__hydra_host__ __hydra_device__ inline Type
 spline(Iterator1 first, Iterator1 last,  Iterator2 measurements, Type value);
 
 /**
@@ -86,14 +87,14 @@ spline(Iterator1 first, Iterator1 last,  Iterator2 measurements, Type value);
  * @return Interpolated value
  */
 template<typename Iterable1, typename Iterable2, typename Type>
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-					   hydra::detail::is_iterable<Iterable1>::value &&
-                       hydra::detail::is_iterable<Iterable2>::value &&
-                       std::is_convertible<typename Iterable1::value_type, double >::value &&
-                       std::is_convertible<typename Iterable2::value_type, double >::value &&
-					   std::is_convertible<Type, double >::value,
-                       Type >::type
+requires (
+	hydra::detail::Iterable<Iterable1> &&
+	hydra::detail::Iterable<Iterable2> &&
+	std::is_convertible_v<typename Iterable1::value_type, double > &&
+	std::is_convertible_v<typename Iterable2::value_type, double > &&
+	std::is_convertible_v<Type, double >
+)
+__hydra_host__ __hydra_device__ inline Type
 spline(Iterable1&& abiscissae,  Iterable2&& measurements, Type value);
 
 /**
@@ -114,76 +115,77 @@ spline(Iterable1&& abiscissae,  Iterable2&& measurements, Type value);
  * @return
  */
 template<typename IteratorX, typename IteratorY, typename IteratorM, typename TypeX, typename TypeY>
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double >::value &&
-	std::is_convertible<TypeX, double >::value &&
-	std::is_convertible<TypeY, double >::value
-, double>::type
+requires (
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline2D(IteratorX firstx, IteratorX lastx, IteratorY firsty, IteratorY lasty, IteratorM measurements, TypeX x, TypeY y);
 
 
 template<typename IterableX, typename IterableY,typename IterableM, typename TypeX,typename TypeY >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-					   hydra::detail::is_iterable<IterableX>::value &&
-                       hydra::detail::is_iterable<IterableY>::value &&
-                       hydra::detail::is_iterable<IterableM>::value &&
-                       std::is_convertible<typename IterableX::value_type, double >::value &&
-                       std::is_convertible<typename IterableY::value_type, double >::value &&
-					   std::is_convertible<typename IterableM::value_type, double >::value &&
-					   std::is_convertible<TypeX, double >::value &&
-					   std::is_convertible<TypeY, double >::value ,
-                       double >::type
+requires (
+	hydra::detail::Iterable<IterableX> &&
+	hydra::detail::Iterable<IterableY> &&
+	hydra::detail::Iterable<IterableM> &&
+	std::is_convertible_v<typename IterableX::value_type, double > &&
+	std::is_convertible_v<typename IterableY::value_type, double > &&
+	std::is_convertible_v<typename IterableM::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline(IterableX&& abcissa_x,  IterableY&& abcissa_y, IterableM measurements, TypeX x, TypeX y);
 
 template<typename IteratorX, typename IteratorY, typename IteratorZ, typename IteratorM, typename TypeX, typename TypeY, typename TypeZ >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorZ>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double >::value &&
-	std::is_convertible<TypeX, double >::value &&
-	std::is_convertible<TypeY, double >::value &&
-	std::is_convertible<TypeZ, double >::value, double>::type
+requires (
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorZ>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double > &&
+	std::is_convertible_v<TypeZ, double >)
+__hydra_host__ __hydra_device__ inline double
 spline3D(IteratorX firstx, IteratorX lastx,
 		 IteratorY firsty, IteratorY lasty,
 		 IteratorY firstz, IteratorY lastz,
 		 IteratorM measurements, TypeX x, TypeY y, TypeZ z);
 
 template<typename IterableX, typename IterableY,typename IterableZ,typename IterableM, typename TypeX,typename TypeY, typename TypeZ >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-					   hydra::detail::is_iterable<IterableX>::value &&
-                       hydra::detail::is_iterable<IterableY>::value &&
-					   hydra::detail::is_iterable<IterableZ>::value &&
-                       hydra::detail::is_iterable<IterableM>::value &&
-                       std::is_convertible<typename IterableX::value_type, double >::value &&
-                       std::is_convertible<typename IterableY::value_type, double >::value &&
-					   std::is_convertible<typename IterableZ::value_type, double >::value &&
-					   std::is_convertible<typename IterableM::value_type, double >::value &&
-					   std::is_convertible<TypeX, double >::value &&
-					   std::is_convertible<TypeY, double >::value &&
-					   std::is_convertible<TypeZ, double >::value ,
-                       double >::type
+requires (
+	hydra::detail::Iterable<IterableX> &&
+	hydra::detail::Iterable<IterableY> &&
+	hydra::detail::Iterable<IterableZ> &&
+	hydra::detail::Iterable<IterableM> &&
+	std::is_convertible_v<typename IterableX::value_type, double > &&
+	std::is_convertible_v<typename IterableY::value_type, double > &&
+	std::is_convertible_v<typename IterableZ::value_type, double > &&
+	std::is_convertible_v<typename IterableM::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double > &&
+	std::is_convertible_v<TypeZ, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline3D(IterableX&& abscissa_x,  IterableY&& abscissa_y, IterableZ&& abscissa_z, IterableM measurements, TypeX x, TypeX y, TypeZ z );
 
 template<typename IteratorX, typename IteratorY, typename IteratorW, typename IteratorZ, typename IteratorM,
           typename TypeX, typename TypeY, typename TypeW, typename TypeZ >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorW>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorZ>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double >::value &&
-	std::is_convertible<TypeX, double >::value &&
-	std::is_convertible<TypeY, double >::value &&
-	std::is_convertible<TypeW, double >::value &&
-	std::is_convertible<TypeZ, double >::value, double>::type
+requires (
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorW>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorZ>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double > &&
+	std::is_convertible_v<TypeW, double > &&
+	std::is_convertible_v<TypeZ, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline4D(IteratorX firstx, IteratorX lastx,
 		 IteratorY firsty, IteratorY lasty,
 		 IteratorW firstw, IteratorW lastw,
@@ -191,23 +193,23 @@ spline4D(IteratorX firstx, IteratorX lastx,
 		 IteratorM measurements, TypeX x, TypeY y, TypeW w, TypeZ z);
 
 template<typename IterableX, typename IterableY,typename IterableW,typename IterableZ,typename IterableM, typename TypeX,typename TypeY, typename TypeW, typename TypeZ >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-					   hydra::detail::is_iterable<IterableX>::value &&
-                       hydra::detail::is_iterable<IterableY>::value &&
-					   hydra::detail::is_iterable<IterableW>::value &&
-					   hydra::detail::is_iterable<IterableZ>::value &&
-                       hydra::detail::is_iterable<IterableM>::value &&
-                       std::is_convertible<typename IterableX::value_type, double >::value &&
-                       std::is_convertible<typename IterableY::value_type, double >::value &&
-					   std::is_convertible<typename IterableW::value_type, double >::value &&
-					   std::is_convertible<typename IterableZ::value_type, double >::value &&
-					   std::is_convertible<typename IterableM::value_type, double >::value &&
-					   std::is_convertible<TypeX, double >::value &&
-					   std::is_convertible<TypeY, double >::value &&
-					   std::is_convertible<TypeW, double >::value &&
-					   std::is_convertible<TypeZ, double >::value ,
-                       double >::type
+requires (
+	hydra::detail::Iterable<IterableX> &&
+	hydra::detail::Iterable<IterableY> &&
+	hydra::detail::Iterable<IterableW> &&
+	hydra::detail::Iterable<IterableZ> &&
+	hydra::detail::Iterable<IterableM> &&
+	std::is_convertible_v<typename IterableX::value_type, double > &&
+	std::is_convertible_v<typename IterableY::value_type, double > &&
+	std::is_convertible_v<typename IterableW::value_type, double > &&
+	std::is_convertible_v<typename IterableZ::value_type, double > &&
+	std::is_convertible_v<typename IterableM::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double > &&
+	std::is_convertible_v<TypeW, double > &&
+	std::is_convertible_v<TypeZ, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline3D(IterableX&& abscissa_x,  IterableY&& abscissa_y, IterableW&& abscissa_w, IterableZ&& abscissa_z, IterableM measurements, TypeX x, TypeX y, TypeW w, TypeZ z );
 
 } // namespace hydra

--- a/hydra/Zip.h
+++ b/hydra/Zip.h
@@ -39,14 +39,15 @@
 
 
 #include <utility>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
 
 template<typename ...Iterables>
-typename std::enable_if< detail::all_true< detail::is_iterable<Iterables>::value...>::value,
+requires (detail::all_true< detail::Iterable<Iterables>...>::value)
 Range< hydra::thrust::zip_iterator<
-	decltype(hydra::thrust::make_tuple(std::declval<Iterables&>().begin()...))>>>::type
+	decltype(hydra::thrust::make_tuple(std::declval<Iterables&>().begin()...))>>
 zip(Iterables&&... iterables){
 
 	return make_range( hydra::thrust::make_zip_iterator(hydra::thrust::make_tuple(std::forward<Iterables>(iterables).begin()...)),

--- a/hydra/detail/BaseCompositeFunctor.h
+++ b/hydra/detail/BaseCompositeFunctor.h
@@ -37,6 +37,7 @@
 #include <hydra/Parameter.h>
 #include <hydra/detail/utility/Utility_Tuple.h>
 #include <hydra/detail/FunctorTraits.h>
+#include <hydra/detail/TupleConcepts.h>
 #include <hydra/detail/ParametersCompositeFunctor.h>
 //#include <hydra/UserParameters.h>
 
@@ -118,10 +119,8 @@ public:
 
 
 	template<typename ...T>
-	__hydra_host__  __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_valid_type_pack< argument_type, T...>::value),
-	return_type>::type
+	requires ((!detail::ValidTypePack<argument_type, T...>))
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(T...x)  const
 	{
 		//typename hydra::tuple<T...>::dummy a;
@@ -146,10 +145,8 @@ public:
 	 * the lambda signature
 	 */
 	template<typename ...T>
-	__hydra_host__  __hydra_device__
-	inline typename std::enable_if<
-	detail::is_valid_type_pack< argument_type, T...>::value,
-	return_type>::type
+	requires (detail::ValidTypePack<argument_type, T...>)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(T...x)  const
 	{
 		return static_cast<const Composite*>(this)->Evaluate(x...);
@@ -161,12 +158,12 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type< typename std::decay<T>::type >::value )                 &&
-	(!detail::is_tuple_of_function_arguments< typename std::decay<T>::type >::value) &&
-	( hydra::thrust::detail::is_convertible< typename std::decay<T>::type,  argument_type >::value ),
-	return_type >::type
+	requires (
+		( detail::TupleType<T> ) &&
+		(!detail::TupleOfFunctionArguments<T>) &&
+		( hydra::thrust::detail::is_convertible< typename std::decay<T>::type, argument_type >::value )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T x )  const
 	{
 		return  raw_call(x);
@@ -178,11 +175,8 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type<typename std::decay<T>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T>::type >::value),
-	return_type>::type
+	requires (( detail::TupleType<T> ) && ( detail::TupleOfFunctionArguments<T>))
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T x )  const
 	{
 		return  call(x);
@@ -195,13 +189,13 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	( detail::is_tuple_type<typename std::decay<T1>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type<typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ) ,
-	return_type>::type
+	requires (
+		( detail::TupleType<T1> ) &&
+		( detail::TupleOfFunctionArguments<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T1 x, T2 y )  const
 	{
 		auto z = hydra::thrust::tuple_cat(x, y);
@@ -216,13 +210,13 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_tuple_type< typename std::decay<T1>::type>::value ) &&
-	( detail::is_function_argument< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type< typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ),
-	return_type>::type
+	requires (
+		(!detail::TupleType<T1> ) &&
+		( detail::FunctionArgumentArg<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()( T1 x, T2 y )  const
 	{
 		auto z = hydra::thrust::tuple_cat(hydra::thrust::make_tuple(x), y);
@@ -236,13 +230,13 @@ public:
 	 * the lambda arguments in any other.
 	 */
 	template<typename T1, typename T2>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	(!detail::is_tuple_type< typename std::decay<T1>::type>::value ) &&
-	( detail::is_function_argument< typename std::decay<T1>::type >::value ) &&
-	( detail::is_tuple_type< typename std::decay<T2>::type>::value ) &&
-	( detail::is_tuple_of_function_arguments< typename std::decay<T2>::type >::value ),
-	return_type>::type
+	requires (
+		(!detail::TupleType<T1> ) &&
+		( detail::FunctionArgumentArg<T1> ) &&
+		( detail::TupleType<T2> ) &&
+		( detail::TupleOfFunctionArguments<T2> )
+	)
+	__hydra_host__ __hydra_device__ inline return_type
 	operator()(  T2 y, T1 x )  const
 	{
 		auto z = hydra::thrust::tuple_cat(hydra::thrust::make_tuple(x), y);

--- a/hydra/detail/BooststrappedRange.inl
+++ b/hydra/detail/BooststrappedRange.inl
@@ -33,14 +33,15 @@
 #include <hydra/detail/functors/RandomUtils.h>
 #include <hydra/detail/external/hydra_thrust/iterator/permutation_iterator.h>
 #include <utility>
+#include <hydra/detail/IteratorConcepts.h>
 namespace hydra {
 
 
 template<typename Iterable>
-typename std::enable_if<hydra::detail::is_iterable<Iterable>::value,
-   Range< hydra::thrust::permutation_iterator<decltype(std::declval<Iterable&>().begin()),
+requires (hydra::detail::Iterable<Iterable>)
+Range< hydra::thrust::permutation_iterator<decltype(std::declval<Iterable&>().begin()),
 		 hydra::thrust::transform_iterator< detail::RndUniform<size_t, hydra::thrust::random::default_random_engine>
- ,hydra::thrust::counting_iterator<size_t>,size_t > > >>::type
+ ,hydra::thrust::counting_iterator<size_t>,size_t > > >
 boost_strapped_range(Iterable&& iterable, size_t seed){
 
 	using hydra::thrust::make_permutation_iterator;

--- a/hydra/detail/CollectRange.h
+++ b/hydra/detail/CollectRange.h
@@ -29,19 +29,18 @@
 #ifndef COLLECTRANGE_H_
 #define COLLECTRANGE_H_
 
-
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
 
 template<typename Iterable_Index, typename Iterable_Values>
+requires (hydra::detail::Iterable<Iterable_Index> && hydra::detail::Iterable<Iterable_Values>)
 auto collect( Iterable_Index& indexing_scheme, Iterable_Values& collected_values)
--> typename std::enable_if<hydra::detail::is_iterable<Iterable_Index>::value
-					    && hydra::detail::is_iterable<Iterable_Values>::value,
-Range<hydra::thrust::permutation_iterator<
+-> Range<hydra::thrust::permutation_iterator<
 		decltype(std::declval<Iterable_Values&>().begin()),
 		decltype(std::declval<Iterable_Index&>().begin())>
->::type
+>
 {
 	typedef hydra::thrust::permutation_iterator<Iterable_Values,Iterable_Index> collect_iterator;
 	return make_range(collect_iterator(begin(collected_values), begin(indexing_scheme) ),

--- a/hydra/detail/Compose.h
+++ b/hydra/detail/Compose.h
@@ -37,6 +37,7 @@
 #include <hydra/detail/Constant.h>
 //#include <hydra/detail/CompositeBase.h>
 #include <hydra/detail/FunctorTraits.h>
+#include <hydra/detail/FunctorConcepts.h>
 #include <hydra/detail/CompositeTraits.h>
 #include <hydra/Parameter.h>
 #include <hydra/Tuple.h>
@@ -120,12 +121,8 @@ public:
 
 // Conveniency function
 template < typename T0, typename T1, typename ...Ts >
-inline typename std::enable_if<
-(detail::is_hydra_functor<T0>::value || detail::is_hydra_lambda<T0>::value ) &&
-(detail::is_hydra_functor<T1>::value || detail::is_hydra_lambda<T1>::value ) &&
-detail::all_true<
-(detail::is_hydra_functor<Ts>::value || detail::is_hydra_lambda<Ts>::value )...>::value,
-Compose<T0,T1,Ts...>>::type
+requires (detail::HydraCallable<T0> && detail::HydraCallable<T1> && (detail::HydraCallable<Ts> && ...))
+inline Compose<T0,T1,Ts...>
 compose(T0 const& F0, T1 const& F1, Ts const&...Fs){
 
 	return  Compose<T0,T1,Ts...>(F0, F1, Fs...);

--- a/hydra/detail/CompositeBase.h
+++ b/hydra/detail/CompositeBase.h
@@ -40,6 +40,7 @@
 #include <hydra/Parameter.h>
 #include <hydra/Placeholders.h>
 #include <hydra/detail/TupleTraits.h>
+#include <concepts>
 
 namespace hydra {
 
@@ -73,12 +74,13 @@ public:
 	{}
 
 	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	std::is_copy_constructible<F0>::value &&
-	std::is_copy_constructible<F1>::value &&
-	detail::all_true<std::is_copy_constructible<Fs>::value...>::value,
-		 CompositeBase<F0,F1,Fs...>&>::type
+	inline CompositeBase<F0,F1,Fs...>&
     operator=(CompositeBase<F0,F1,Fs...> const& other)
+	requires (
+		(std::is_copy_constructible_v<F0>) &&
+	    (std::is_copy_constructible_v<F1>) &&
+	    (detail::all_true<std::is_copy_constructible_v<Fs>...>::value)
+	)
 	{
 		if(this==&other)return *this;
 
@@ -131,8 +133,8 @@ public:
 
 	}
 
-	template<typename Int,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline const hydra::Parameter& GetParameter(Int i) const {
 
 		std::vector<hydra::Parameter*> _parameters;
@@ -155,8 +157,8 @@ public:
 		return *(_parameters[i]) ;
 	}
 
-	template<typename Int,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline hydra::Parameter& Parameter(Int i) {
 
 		std::vector<hydra::Parameter*> _parameters;
@@ -179,8 +181,8 @@ public:
 	}
 
 
-	template<typename Int,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline void SetParameter(Int i, hydra::Parameter const& value) {
 
 		std::vector<hydra::Parameter*> _parameters;
@@ -189,8 +191,8 @@ public:
 		*(_parameters[i])=value;
 	}
 
-	template<typename Int,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline void SetParameter(Int i, double value) {
 		std::vector<hydra::Parameter*> _parameters;
 		detail::add_parameters_in_tuple(_parameters, fFtorTuple );

--- a/hydra/detail/Copy.inl
+++ b/hydra/detail/Copy.inl
@@ -36,15 +36,15 @@
 #include <hydra/detail/external/hydra_thrust/copy.h>
 #include <hydra/Range.h>
 #include <utility>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
 
 
 template<typename Iterable_Source, typename Iterable_Target>
-typename std::enable_if<hydra::detail::is_iterable<Iterable_Source>::value
-&& hydra::detail::is_iterable<Iterable_Target>::value,
-Range<decltype(std::declval<Iterable_Target&>().begin())>>::type
+requires (hydra::detail::Iterable<Iterable_Source> && hydra::detail::Iterable<Iterable_Target>)
+Range<decltype(std::declval<Iterable_Target&>().begin())>
 copy(Iterable_Source&& source, Iterable_Target&& destination)
 {
 	hydra::thrust::copy(std::forward<Iterable_Source>(source).begin(),

--- a/hydra/detail/CountingRange.inl
+++ b/hydra/detail/CountingRange.inl
@@ -32,6 +32,7 @@
 #include <hydra/detail/Config.h>
 #include <hydra/detail/external/hydra_thrust/iterator/counting_iterator.h>
 #include <type_traits>
+#include <concepts>
 
 namespace hydra {
 
@@ -91,8 +92,8 @@ range(long int first, long int last ){
 }
 
 template<typename T>
-inline typename std::enable_if< std::is_floating_point<T>::value,
-   Range<hydra::thrust::counting_iterator<unsigned>, detail::range::Shift<T>> >::type
+requires (std::floating_point<T>)
+inline Range<hydra::thrust::counting_iterator<unsigned>, detail::range::Shift<T>>
 range(T min, T max, unsigned nbins ){
 
 	T delta = (max-min)/nbins;

--- a/hydra/detail/Decays.inl
+++ b/hydra/detail/Decays.inl
@@ -31,6 +31,7 @@
 
 #include <hydra/detail/Config.h>
 #include <hydra/detail/BackendPolicy.h>
+#include <hydra/detail/FunctorConcepts.h>
 #include <hydra/Vector4R.h>
 #include <hydra/Tuple.h>
 #include <hydra/Function.h>
@@ -340,9 +341,8 @@ public:
 	}
 
     template<typename T=Functor>
-	__hydra_host__ __hydra_device__
-	typename std::enable_if<std::is_copy_assignable<T>::value,
-	PhaseSpaceReweight<T, ParticleTypes...> &>::type
+    requires (std::is_copy_assignable_v<T>)
+    __hydra_host__ __hydra_device__ PhaseSpaceReweight<T, ParticleTypes...> &
 	operator=(PhaseSpaceReweight<T, ParticleTypes...> const& other )
 	{
 
@@ -456,11 +456,11 @@ Decays<hydra::tuple<Particles...>, hydra::detail::BackendPolicy<Backend>>::Unwei
 
 template<typename ...Particles,   hydra::detail::Backend Backend>
 template<typename  Functor>
-typename std::enable_if<
- 	detail::is_hydra_functor<Functor>::value ||
- 	detail::is_hydra_lambda<Functor>::value  ||
- 	detail::is_hydra_composite_functor<Functor>::value,
-	hydra::Range<typename  Decays<hydra::tuple<Particles...>, hydra::detail::BackendPolicy<Backend>>::iterator>>::type
+requires (
+	detail::HydraCallable<Functor> ||
+ 	detail::HydraCompositeFunctor<Functor>
+)
+hydra::Range<typename  Decays<hydra::tuple<Particles...>, hydra::detail::BackendPolicy<Backend>>::iterator>
 Decays<hydra::tuple<Particles...>, hydra::detail::BackendPolicy<Backend>>::Unweight( Functor  const& functor, double max_weight, size_t seed)
 {
 /*

--- a/hydra/detail/DenseHistogram.inl
+++ b/hydra/detail/DenseHistogram.inl
@@ -40,6 +40,7 @@
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
 #include <hydra/detail/external/hydra_thrust/system/detail/generic/select_system.h>
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -519,7 +520,8 @@ DenseHistogram<T,1, detail::BackendPolicy<BACKEND>, detail::unidimensional >::Fi
 
 template<typename T,  size_t N , hydra::detail::Backend BACKEND>
 template<size_t M>
-inline typename std::enable_if< M==2, T >::type
+requires (M==2)
+inline T
 DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>::Interpolate( std::array<size_t,2> const&  point){
 
 	return spline2D(this->GetBinsCenters(placeholders::_0).begin(), this->GetBinsCenters(placeholders::_0).end(),
@@ -529,7 +531,8 @@ DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 
 template<typename T,  size_t N , hydra::detail::Backend BACKEND>
 template<size_t M>
-inline typename std::enable_if< M==3, T >::type
+requires (M==3)
+inline T
 DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>::Interpolate( std::array<size_t,3> const&  point){
 
 	return spline3D(this->GetBinsCenters(placeholders::_0).begin(), this->GetBinsCenters(placeholders::_0).end(),
@@ -541,7 +544,8 @@ DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 
 template<typename T, size_t N , hydra::detail::Backend BACKEND>
 template<size_t M>
-inline typename std::enable_if< M==4, T >::type
+requires (M==4)
+inline T
 DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>::Interpolate( std::array<size_t,4> const&  point){
 
 	return spline4D(
@@ -580,8 +584,8 @@ make_dense_histogram( detail::BackendPolicy<BACKEND>, std::array<size_t, N> cons
 
 //iterable based
 template< typename T, size_t N , hydra::detail::Backend BACKEND, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 make_dense_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t, N> const& grid,
 		std::array<double, N> const& lowerlimits,   std::array<double, N> const& upperlimits,	Iterable&& data){
 
@@ -591,9 +595,8 @@ make_dense_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t,
 }
 
 template< typename T, size_t N , hydra::detail::Backend BACKEND, typename Iterable1,typename Iterable2 >
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value&&
-                                hydra::detail::is_iterable<Iterable2>::value,
-DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>>::type
+requires (hydra::detail::Iterable<Iterable1>&& hydra::detail::Iterable<Iterable2>)
+inline DenseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 make_dense_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t, N>const&  grid,
 		std::array<double, N>const& lowerlimits,   std::array<double, N>const&  upperlimits,
 		Iterable1&& data,
@@ -636,8 +639,8 @@ make_dense_histogram( detail::BackendPolicy<BACKEND>, size_t grid, double lowerl
 
 //iterable based
 template< typename T, hydra::detail::Backend BACKEND, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-DenseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline DenseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>
 make_dense_histogram( detail::BackendPolicy<BACKEND> backend, size_t grid,
 		double lowerlimits, double upperlimits,	Iterable&& data){
 
@@ -647,9 +650,8 @@ make_dense_histogram( detail::BackendPolicy<BACKEND> backend, size_t grid,
 }
 
 template< typename T, hydra::detail::Backend BACKEND, typename Iterable1,typename Iterable2 >
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value&&
-hydra::detail::is_iterable<Iterable2>::value,
-DenseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>>::type
+requires (hydra::detail::Iterable<Iterable1>&& hydra::detail::Iterable<Iterable2>)
+inline DenseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>
 make_dense_histogram( detail::BackendPolicy<BACKEND> backend, size_t grid,
 		double lowerlimits, double upperlimits, Iterable1&& data, Iterable2&& weights){
 

--- a/hydra/detail/Divide.h
+++ b/hydra/detail/Divide.h
@@ -43,6 +43,7 @@
 #include <hydra/detail/Constant.h>
 #include <hydra/Complex.h>
 #include <hydra/detail/FunctorTraits.h>
+#include <hydra/detail/FunctorConcepts.h>
 #include <hydra/Parameter.h>
 #include <hydra/Tuple.h>
 #include <hydra/detail/BaseCompositeFunctor.h>
@@ -116,50 +117,40 @@ public:
 
 // divide: / operator two functors
 template<typename T1, typename T2>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T1>::value || detail::is_hydra_lambda<T1>::value) &&
-(detail::is_hydra_functor<T2>::value || detail::is_hydra_lambda<T2>::value),
-Divide<T1, T2> >::type
+requires (detail::HydraCallable<T1> && detail::HydraCallable<T2>)
+inline Divide<T1, T2>
 operator/(T1 const& F1, T2 const& F2)
 {
 	return Divide<T1,T2>(F1, F2);
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Divide< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Divide< Constant<U>, T>
 operator/(U const cte, T const& F)
 {
 	return Constant<U>(cte)/F;
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Divide< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Divide< Constant<U>, T>
 operator/( T const& F, U cte)
 {
 	return F/Constant<U>(cte);
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Divide< Constant<hydra::complex<U>>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Divide< Constant<hydra::complex<U>>, T>
 operator/(hydra::complex<U> const& cte, T const& F)
 {
 	return  Constant<hydra::complex<U> >(cte)/F;
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Divide< Constant<hydra::complex<U>>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Divide< Constant<hydra::complex<U>>, T>
 operator/( T const& F, hydra::complex<U> const& cte)
 {
 	return  F/Constant<hydra::complex<U> >(cte);
@@ -168,10 +159,8 @@ operator/( T const& F, hydra::complex<U> const& cte)
 
 // Convenience function
 template <typename F1, typename F2, typename ...Fs>
-inline typename std::enable_if<
-(detail::is_hydra_functor<F1>::value || detail::is_hydra_lambda<F1>::value ) &&
-(detail::is_hydra_functor<F2>::value || detail::is_hydra_lambda<F2>::value ),
-Divide<F1, F2>>::type
+requires (detail::HydraCallable<F1> && detail::HydraCallable<F2>)
+inline Divide<F1, F2>
 divide(F1 const& f1, F2 const& f2)
 {
 	return  Divide<F1, F2>(f1,f2);

--- a/hydra/detail/FCN3.inl
+++ b/hydra/detail/FCN3.inl
@@ -128,11 +128,13 @@ public:
 private:
 
 	template<size_t I>
-	typename std::enable_if<(I==nfcns), void>::type
+	requires ((I==nfcns))
+	void
 	load_fcn_parameters_helper(std::vector<Parameter*>&){}
 
 	template<size_t I=0>
-	typename std::enable_if< (I<nfcns), void>::type
+	requires ((I<nfcns))
+	void
 	load_fcn_parameters_helper( std::vector<Parameter*>& pars){
 
 		auto vars = hydra::thrust::get<I>(fFCNS).GetParameters().GetVariables();
@@ -153,11 +155,13 @@ private:
 	}
 
 	template<size_t I>
-	typename std::enable_if< (I==nfcns), void>::type
+	requires ((I==nfcns))
+	void
 	add_tasks( std::vector<double> const& parameters, std::vector<std::future<double>>&  ) const {}
 
 	template<size_t I=0>
-	typename std::enable_if< (I<nfcns), void>::type
+	requires ((I<nfcns))
+	void
 	add_tasks(std::vector<double> const& parameters, std::vector<std::future<double>>& tasks ) const
 	{
 		tasks.push_back(std::async(

--- a/hydra/detail/Filter.inl
+++ b/hydra/detail/Filter.inl
@@ -33,8 +33,8 @@
 namespace hydra {
 
 template<typename Iterable, typename Functor>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 filter(Iterable&& container, Functor&& filter)
 {
 
@@ -46,9 +46,9 @@ filter(Iterable&& container, Functor&& filter)
 }
 
 template<typename Iterable, typename Functor>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-std::pair<hydra::Range<decltype(std::declval<Iterable>().begin())>,
-          hydra::Range<decltype(std::declval<Iterable>().begin())>>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline std::pair<hydra::Range<decltype(std::declval<Iterable>().begin())>,
+          hydra::Range<decltype(std::declval<Iterable>().begin())>>
 segregate(Iterable&& container, Functor&& filter)
 {
 

--- a/hydra/detail/ForEach.inl
+++ b/hydra/detail/ForEach.inl
@@ -35,12 +35,13 @@
 #include <hydra/Types.h>
 #include <hydra/detail/external/hydra_thrust/for_each.h>
 #include <utility>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
 template<typename Iterable, typename Functor>
-	typename std::enable_if<hydra::detail::is_iterable<Iterable>::value,
-	Range<decltype(std::declval<Iterable&>().begin())>>::type
+requires (hydra::detail::Iterable<Iterable>)
+Range<decltype(std::declval<Iterable&>().begin())>
 for_each(Iterable&& iterable, Functor const& functor)
 {
 	hydra::thrust::for_each( std::forward<Iterable>(iterable).begin(),

--- a/hydra/detail/FunctionArgument.h
+++ b/hydra/detail/FunctionArgument.h
@@ -36,6 +36,20 @@ namespace hydra {
 
 namespace detail {
 
+/*
+ * Helper concepts to reduce the repetition in the function-argument
+ * operator overloads below.
+ */
+
+// T is a Hydra function argument
+template<typename T>
+concept FunctionArg = is_function_argument<T>::value;
+
+// Arg1 and Arg2 together form a function-argument pack
+template<typename Arg1, typename Arg2>
+concept FunctionArgPack = is_function_argument_pack<Arg1, Arg2>::value;
+
+
 template<typename Derived, typename Type>
 struct FunctionArgument
 {
@@ -78,9 +92,8 @@ struct FunctionArgument
     }
 
     template<typename T>
-    __hydra_host__ __hydra_device__
-    typename  std::enable_if< std::is_convertible<T, value_type>::value && (!detail::is_function_argument<T>::value),
-    FunctionArgument<name_type, value_type>&>::type
+    requires (std::is_convertible_v<T, value_type> && (!detail::FunctionArg<T>))
+    __hydra_host__ __hydra_device__ FunctionArgument<name_type, value_type>&
     operator=(T other)
     {
     	value = other;
@@ -88,9 +101,8 @@ struct FunctionArgument
     }
 
     template<typename T>
-    __hydra_host__ __hydra_device__
-    typename  std::enable_if< std::is_convertible<T, value_type>::value && (!detail::is_function_argument<T>::value),
-       FunctionArgument<name_type, value_type>&>::type
+    requires (std::is_convertible_v<T, value_type> && (!detail::FunctionArg<T>))
+    __hydra_host__ __hydra_device__ FunctionArgument<name_type, value_type>&
     operator=(hydra::thrust::device_reference<T> const& other)
     {
     	value = other;
@@ -176,9 +188,8 @@ struct FunctionArgument
     //=============================================================
 
     template<typename Derived2, typename Type2>
-    __hydra_host__ __hydra_device__
-    typename std::enable_if<std::is_convertible<Type, Type2>::value,
-    FunctionArgument<Derived, Type>&>::type
+    requires (std::is_convertible_v<Type, Type2>)
+    __hydra_host__ __hydra_device__ FunctionArgument<Derived, Type>&
     operator+=( FunctionArgument<Derived2, Type2> const & other)
 	{
         value+=other();
@@ -186,9 +197,8 @@ struct FunctionArgument
 	}
 
     template<typename Derived2, typename Type2>
-    __hydra_host__ __hydra_device__
-    typename std::enable_if<std::is_convertible<Type, Type2>::value,
-    FunctionArgument<Derived, Type>&>::type
+    requires (std::is_convertible_v<Type, Type2>)
+    __hydra_host__ __hydra_device__ FunctionArgument<Derived, Type>&
     operator-=( FunctionArgument<Derived2, Type2> const & other)
 	{
         value-=other();
@@ -196,9 +206,8 @@ struct FunctionArgument
 	}
 
     template<typename Derived2, typename Type2>
-    __hydra_host__ __hydra_device__
-    typename std::enable_if<std::is_convertible<Type, Type2>::value,
-    FunctionArgument<Derived, Type>&>::type
+    requires (std::is_convertible_v<Type, Type2>)
+    __hydra_host__ __hydra_device__ FunctionArgument<Derived, Type>&
     operator*=( FunctionArgument<Derived2, Type2> const & other)
 	{
         value*=other();
@@ -206,9 +215,8 @@ struct FunctionArgument
 	}
 
     template<typename Derived2, typename Type2>
-    __hydra_host__ __hydra_device__
-    typename std::enable_if<std::is_convertible<Type, Type2>::value,
-    FunctionArgument<Derived, Type>&>::type
+    requires (std::is_convertible_v<Type, Type2>)
+    __hydra_host__ __hydra_device__ FunctionArgument<Derived, Type>&
     operator/=( FunctionArgument<Derived2, Type2> const & other)
 	{
         value/=other();
@@ -217,9 +225,8 @@ struct FunctionArgument
 
 
     template<typename Derived2, typename Type2>
-    __hydra_host__ __hydra_device__
-    typename std::enable_if<std::is_convertible<Type, Type2>::value,
-    FunctionArgument<Derived, Type>&>::type
+    requires (std::is_convertible_v<Type, Type2>)
+    __hydra_host__ __hydra_device__ FunctionArgument<Derived, Type>&
     operator%=( FunctionArgument<Derived2, Type2> const & other)
 	{
         value%=other();
@@ -298,11 +305,9 @@ __hydra_host__ __hydra_device__										   \
   }                                                                    \
                                                                        \
   template<typename T>                                                 \
-  typename std::enable_if<                                             \
-        std::is_base_of< detail::FunctionArgument<T, TYPE>, T>::value, \
-        NAME& >::type                                                  \
+  requires (std::is_base_of< detail::FunctionArgument<T, TYPE>, T>::value) \
   __hydra_host__ __hydra_device__                                      \
-  operator=(T const& other)                                            \
+  NAME& operator=(T const& other)                                      \
   {                                                                    \
                                                                        \
         super_type::operator=(other);                                  \
@@ -319,9 +324,8 @@ namespace hydra {
 namespace arguments  {
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument<Arg1>::value && !detail::is_function_argument<Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()+  std::declval<Arg2>() )>::type
+requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()+  std::declval<Arg2>() )
 operator+( Arg1 const& a1, Arg2 const& a2) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()+
@@ -331,9 +335,8 @@ operator+( Arg1 const& a1, Arg2 const& a2) {
 }
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument<Arg1>::value && !detail::is_function_argument<Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()+  std::declval<Arg2>() )>::type
+requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()+  std::declval<Arg2>() )
 operator+(Arg2 const& a2, Arg1 const& a1 ) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()+
@@ -344,10 +347,9 @@ operator+(Arg2 const& a2, Arg1 const& a1 ) {
 
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument_pack<Arg1, Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()+
-		 std::declval<typename  Arg2::value_type>() )>::type
+requires (detail::FunctionArgPack<Arg1, Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()+
+		 std::declval<typename  Arg2::value_type>() )
 operator+( Arg1 const& a1, Arg2 const& a2) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()+
@@ -359,9 +361,8 @@ operator+( Arg1 const& a1, Arg2 const& a2) {
 //---------------
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument<Arg1>::value && !detail::is_function_argument<Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()- std::declval<Arg2>() )>::type
+requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()- std::declval<Arg2>() )
 operator-( Arg1 const& a1, Arg2 const& a2) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()-
@@ -371,9 +372,8 @@ operator-( Arg1 const& a1, Arg2 const& a2) {
 }
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument<Arg1>::value && !detail::is_function_argument<Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()-  std::declval<Arg2>() )>::type
+requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()-  std::declval<Arg2>() )
 operator-(Arg2 const& a2, Arg1 const& a1 ) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()-
@@ -383,10 +383,9 @@ operator-(Arg2 const& a2, Arg1 const& a1 ) {
 }
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument_pack<Arg1, Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()-
-		 std::declval<typename  Arg2::value_type>() )>::type
+requires (detail::FunctionArgPack<Arg1, Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()-
+		 std::declval<typename  Arg2::value_type>() )
 operator-( Arg1 const& a1, Arg2 const& a2) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()-
@@ -399,9 +398,8 @@ operator-( Arg1 const& a1, Arg2 const& a2) {
 //----------------
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument<Arg1>::value && !detail::is_function_argument<Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()* std::declval<Arg2>() )>::type
+requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()* std::declval<Arg2>() )
 operator*( Arg1 const& a1, Arg2 const& a2) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()-
@@ -411,9 +409,8 @@ operator*( Arg1 const& a1, Arg2 const& a2) {
 }
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument<Arg1>::value && !detail::is_function_argument<Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()*  std::declval<Arg2>() )>::type
+requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()*  std::declval<Arg2>() )
 operator*(Arg2 const& a2, Arg1 const& a1 ) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()-
@@ -423,10 +420,9 @@ operator*(Arg2 const& a2, Arg1 const& a1 ) {
 }
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument_pack<Arg1, Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()*
-		 std::declval<typename  Arg2::value_type>() )>::type
+requires (detail::FunctionArgPack<Arg1, Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()*
+		 std::declval<typename  Arg2::value_type>() )
 operator*( Arg1 const& a1, Arg2 const& a2) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()*
@@ -438,9 +434,8 @@ operator*( Arg1 const& a1, Arg2 const& a2) {
 //----------------
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument<Arg1>::value && !detail::is_function_argument<Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>() / std::declval<Arg2>() )>::type
+requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>() / std::declval<Arg2>() )
 operator/( Arg1 const& a1, Arg2 const& a2) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()-
@@ -450,9 +445,8 @@ operator/( Arg1 const& a1, Arg2 const& a2) {
 }
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument<Arg1>::value && !detail::is_function_argument<Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>() / std::declval<Arg2>() )>::type
+requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>() / std::declval<Arg2>() )
 operator/(Arg2 const& a2, Arg1 const& a1 ) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()-
@@ -462,10 +456,9 @@ operator/(Arg2 const& a2, Arg1 const& a1 ) {
 }
 
 template<typename Arg1, typename Arg2>
-__hydra_host__ __hydra_device__
-typename std::enable_if<detail::is_function_argument_pack<Arg1, Arg2>::value,
-decltype(std::declval<typename  Arg1::value_type>()/
-		 std::declval<typename  Arg2::value_type>() )>::type
+requires (detail::FunctionArgPack<Arg1, Arg2>)
+__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()/
+		 std::declval<typename  Arg2::value_type>() )
 operator/( Arg1 const& a1, Arg2 const& a2) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()/
@@ -477,14 +470,16 @@ operator/( Arg1 const& a1, Arg2 const& a2) {
 
 
 template<typename Arg>
-inline typename std::enable_if<detail::is_function_argument<Arg>::value, std::ostream&>::type
+requires (detail::FunctionArg<Arg>)
+inline std::ostream&
 operator<<(std::ostream& s, const hydra::thrust::device_reference<Arg>& a){
 	s <<  typename Arg::name_type(a).Value();
 	return s;
 }
 
 template<typename Arg>
-inline typename std::enable_if<detail::is_function_argument<Arg>::value, std::ostream&>::type
+requires (detail::FunctionArg<Arg>)
+inline std::ostream&
 operator<<(std::ostream& s, const Arg& a){
 	s <<  a.Value();
 	return s;

--- a/hydra/detail/FunctorConcepts.h
+++ b/hydra/detail/FunctorConcepts.h
@@ -1,0 +1,52 @@
+/*----------------------------------------------------------------------------
+ *
+ *   Copyright (C) 2016 - 2023 Antonio Augusto Alves Junior
+ *
+ *   This file is part of Hydra Data Analysis Framework.
+ *
+ *   Hydra is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Hydra is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Hydra.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *---------------------------------------------------------------------------*/
+
+/*
+ * FunctorConcepts.h
+ *
+ *  Created on: 26/06/2026
+ *      Author: Davide Brundu
+ */
+
+#ifndef FUNCTORCONCEPTS_H_
+#define FUNCTORCONCEPTS_H_
+
+#include <concepts>
+#include <type_traits>
+
+#include <hydra/detail/FunctorTraits.h>
+
+namespace hydra {
+
+namespace detail {
+
+/**
+ * @brief Satisfied when @c T is a Hydra functor or a Hydra lambda, i.e. a
+ * callable that can take part in functor arithmetic.
+ */
+template <typename T>
+concept HydraCallable = is_hydra_functor<T>::value || is_hydra_lambda<T>::value;
+
+}  // namespace detail
+
+}  // namespace hydra
+
+#endif /* FUNCTORCONCEPTS_H_ */

--- a/hydra/detail/FunctorConcepts.h
+++ b/hydra/detail/FunctorConcepts.h
@@ -33,17 +33,37 @@
 #include <type_traits>
 
 #include <hydra/detail/FunctorTraits.h>
+#include <hydra/detail/CompositeTraits.h>
+
 
 namespace hydra {
 
 namespace detail {
 
 /**
+ * @brief Satisfied when @c T is a Hydra functor (see hydra::detail::is_hydra_functor).
+ */
+template <typename T>
+concept HydraFunctor = is_hydra_functor<T>::value;
+
+/**
+ * @brief Satisfied when @c T is a Hydra composite functor (see hydra::detail::is_hydra_composite_functor).
+ */
+template <typename T>
+concept HydraCompositeFunctor = is_hydra_composite_functor<T>::value;
+
+/**
+ * @brief Satisfied when @c T is a Hydra lambda (see hydra::detail::is_hydra_lambda).
+ */
+template <typename T>
+concept HydraLambda = is_hydra_lambda<T>::value;
+
+/**
  * @brief Satisfied when @c T is a Hydra functor or a Hydra lambda, i.e. a
  * callable that can take part in functor arithmetic.
  */
 template <typename T>
-concept HydraCallable = is_hydra_functor<T>::value || is_hydra_lambda<T>::value;
+concept HydraCallable = HydraFunctor<T> || HydraLambda<T>;
 
 }  // namespace detail
 

--- a/hydra/detail/Gather.inl
+++ b/hydra/detail/Gather.inl
@@ -37,14 +37,17 @@
 #include <utility>
 #include <hydra/detail/external/hydra_thrust/gather.h>
 #include <hydra/Range.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
 template<typename Iterable_Source, typename Iterable_Target, typename Iterable_Map>
-typename std::enable_if<hydra::detail::is_iterable<Iterable_Source>::value
-					 && hydra::detail::is_iterable<Iterable_Target>::value
-					 && hydra::detail::is_iterable<Iterable_Map>::value,
-Range<decltype(std::declval<Iterable_Target&>().begin())>>::type
+requires (
+	hydra::detail::Iterable<Iterable_Source> &&
+	hydra::detail::Iterable<Iterable_Target> &&
+	hydra::detail::Iterable<Iterable_Map>
+)
+Range<decltype(std::declval<Iterable_Target&>().begin())>
 gather(Iterable_Source&& source, Iterable_Map&& map, Iterable_Target&& target){
 
 	hydra::thrust::gather(
@@ -59,9 +62,8 @@ gather(Iterable_Source&& source, Iterable_Map&& map, Iterable_Target&& target){
 
 /*
 template<typename Iterable_Source, typename Iterable_Target, typename Iterator_Map>
-typename std::enable_if<hydra::detail::is_iterable<Iterable_Source>::value
-					 && hydra::detail::is_iterable<Iterable_Target>::value,
-Range<decltype(std::declval<Iterable_Target&>().begin())>>::type
+requires (hydra::detail::Iterable<Iterable_Source> && hydra::detail::Iterable<Iterable_Target>)
+Range<decltype(std::declval<Iterable_Target&>().begin())>
 gather(Iterable_Source& source, Range<Iterator_Map>&& map, Iterable_Target& target){
 
 	hydra::thrust::gather( source.begin(), source.end(),
@@ -71,8 +73,8 @@ gather(Iterable_Source& source, Range<Iterator_Map>&& map, Iterable_Target& targ
 
 
 template<typename Iterator_Source, typename Iterable_Target, typename Iterator_Map>
-typename std::enable_if<hydra::detail::is_iterable<Iterable_Target>::value,
-Range<decltype(std::declval<Iterable_Target&>().begin())>>::type
+requires (hydra::detail::Iterable<Iterable_Target>)
+Range<decltype(std::declval<Iterable_Target&>().begin())>
 gather(Range<Iterator_Source>&& source, Range<Iterator_Map>&& map, Iterable_Target& target){
 
 	hydra::thrust::gather( source.begin(), source.end(),

--- a/hydra/detail/GenzMalikRule.h
+++ b/hydra/detail/GenzMalikRule.h
@@ -69,8 +69,9 @@ class GenzMalikRule;
  *
  */
 template<size_t DIM, hydra::detail::Backend   BACKEND>
+requires (DIM>1)
 class GenzMalikRule<DIM, hydra::detail::BackendPolicy<BACKEND>>:
-GenzMalikRuleBase<typename std::enable_if< (DIM>1), void >::type >
+GenzMalikRuleBase<void>
 {
 	typedef  hydra::detail::BackendPolicy<BACKEND> system_type;
 

--- a/hydra/detail/Hash.h
+++ b/hydra/detail/Hash.h
@@ -69,11 +69,13 @@ namespace hydra {
 		namespace tuple {
 
 			template< typename T, unsigned int N, unsigned int I>
-			inline typename std::enable_if< (I == N), void  >::type
+			requires ((I == N))
+			inline void
 			hash_tuple_helper(std::size_t&, T const&){ }
 
 			template< typename T, unsigned int N, unsigned int I=0>
-			inline typename std::enable_if< (I < N), void  >::type
+			requires ((I < N))
+			inline void
 			hash_tuple_helper(std::size_t& seed, T const& _tuple){
 
 				hydra::detail::hash_combine(seed, hydra::get<I>(_tuple));

--- a/hydra/detail/Iterable_traits.h
+++ b/hydra/detail/Iterable_traits.h
@@ -30,6 +30,7 @@
 #define ITERABLE_TRAITS_H_
 
 #include <hydra/Iterator.h>
+#include <hydra/detail/utility/Generic.h>
 #include <utility>
 
 namespace hydra {
@@ -75,6 +76,11 @@ decltype (
         ++std::declval<decltype(hydra::rbegin(std::declval<T&>()))&>(),
         void(*hydra::rbegin(std::declval<T&>())),0)> : std::true_type { };
 */
+
+template<typename ...Iterables>
+struct are_iterables: std::conditional<sizeof...(Iterables)==0, std::true_type,
+		     detail::all_true<detail::is_iterable<Iterables>::value...> >::type{};
+
 }  // namespace detail
 
 }  // namespace hydra

--- a/hydra/detail/IteratorConcepts.h
+++ b/hydra/detail/IteratorConcepts.h
@@ -1,0 +1,66 @@
+/*----------------------------------------------------------------------------
+ *
+ *   Copyright (C) 2016 - 2023 Antonio Augusto Alves Junior
+ *
+ *   This file is part of Hydra Data Analysis Framework.
+ *
+ *   Hydra is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Hydra is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Hydra.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *---------------------------------------------------------------------------*/
+
+/*
+ * IteratorConcepts.h
+ *
+ *  Created on: 26/06/2026
+ *      Author: Davide Brundu
+ */
+
+#ifndef ITERATORCONCEPTS_H_
+#define ITERATORCONCEPTS_H_
+
+#include <concepts>
+#include <type_traits>
+
+#include <hydra/detail/Iterable_traits.h>
+#include <hydra/detail/TypeTraits.h>
+
+namespace hydra {
+
+namespace detail {
+
+/**
+ * @brief Satisfied when @c T models a Hydra iterable, i.e. exposes @c begin()
+ * and @c end() returning iterators (see hydra::detail::is_iterable).
+ */
+template <typename T>
+concept Iterable = is_iterable<T>::value;
+
+/**
+ * @brief Satisfied when @c T models a Hydra reverse-iterable, i.e. exposes
+ * @c rbegin() and @c rend() (see hydra::detail::is_reverse_iterable).
+ */
+template <typename T>
+concept ReverseIterable = is_reverse_iterable<T>::value;
+
+/**
+ * @brief Satisfied when @c T models an iterator (see hydra::detail::is_iterator).
+ */
+template <typename T>
+concept Iterator = is_iterator<T>::value;
+
+}  // namespace detail
+
+}  // namespace hydra
+
+#endif /* ITERATORCONCEPTS_H_ */

--- a/hydra/detail/IteratorConcepts.h
+++ b/hydra/detail/IteratorConcepts.h
@@ -33,6 +33,7 @@
 #include <type_traits>
 
 #include <hydra/detail/Iterable_traits.h>
+#include <hydra/detail/IteratorTraits.h>
 #include <hydra/detail/TypeTraits.h>
 
 namespace hydra {
@@ -47,6 +48,13 @@ template <typename T>
 concept Iterable = is_iterable<T>::value;
 
 /**
+ * @brief Satisfied when @c Ts model Hydra iterables, i.e. expose @c begin()
+ * and @c end() returning iterators (see hydra::detail::are_iterables).
+ */
+template <typename ...Ts>
+concept Iterables = are_iterables<Ts...>::value;
+
+/**
  * @brief Satisfied when @c T models a Hydra reverse-iterable, i.e. exposes
  * @c rbegin() and @c rend() (see hydra::detail::is_reverse_iterable).
  */
@@ -58,6 +66,12 @@ concept ReverseIterable = is_reverse_iterable<T>::value;
  */
 template <typename T>
 concept Iterator = is_iterator<T>::value;
+
+/**
+ * @brief Satisfied when @c Ts model iterators (see hydra::detail::are_iterators).
+ */
+template <typename ...Ts>
+concept Iterators = are_iterators<Ts...>::value;
 
 }  // namespace detail
 

--- a/hydra/detail/IteratorTraits.h
+++ b/hydra/detail/IteratorTraits.h
@@ -30,6 +30,8 @@
 #define ITERATORTRAITS_H_
 
 #include <utility>
+#include <hydra/detail/TypeTraits.h>
+#include <hydra/detail/utility/Generic.h>
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
 #include <hydra/detail/external/hydra_thrust/system/detail/generic/select_system.h>
 
@@ -55,6 +57,11 @@ struct IteratorTraits
 	}
 
 };
+
+
+template<typename ...Iterators>
+struct are_iterators: std::conditional<sizeof...(Iterators)==0, std::true_type,
+		     detail::all_true<detail::is_iterator<Iterators>::value...> >::type{};
 
 
 }  // namespace detail

--- a/hydra/detail/LogLikelihoodFCN1.inl
+++ b/hydra/detail/LogLikelihoodFCN1.inl
@@ -36,6 +36,7 @@
 #include <hydra/detail/functors/LogLikelihood1.h>
 #include <hydra/detail/external/hydra_thrust/transform_reduce.h>
 #include <hydra/detail/external/hydra_thrust/inner_product.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 
 namespace hydra {
@@ -76,7 +77,8 @@ public:
 	}
 
 	template<size_t M = sizeof...(IteratorW)>
-	inline typename std::enable_if<(M==0), double >::type
+	requires ((M==0))
+	inline double
 	Eval( const std::vector<double>& parameters ) const{
 
 		using   hydra::thrust::system::detail::generic::select_system;
@@ -111,7 +113,8 @@ public:
 	}
 
 	template<size_t M = sizeof...(IteratorW)>
-	inline typename std::enable_if<(M>0), double >::type
+	requires ((M>0))
+	inline double
 	Eval( const std::vector<double>& parameters ) const{
 
 		using   hydra::thrust::system::detail::generic::select_system;
@@ -150,8 +153,8 @@ public:
 
 
 template< typename Functor, typename Integrator,  typename Iterator, typename ...Iterators>
-inline typename std::enable_if< detail::is_iterator<Iterator>::value && detail::are_iterators<Iterators...>::value,
-     LogLikelihoodFCN< Pdf<Functor,Integrator>, Iterator , Iterators... > >::type
+requires (detail::Iterator<Iterator> && detail::Iterators<Iterators...>)
+inline LogLikelihoodFCN< Pdf<Functor,Integrator>, Iterator , Iterators... >
 make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Iterator first, Iterator last,  Iterators... weights )
 {
 
@@ -161,14 +164,17 @@ make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Iterator first, Iterato
 
 
 template< typename Functor, typename Integrator, typename Iterable, typename ...Iterables>
-inline typename std::enable_if< (!detail::is_iterator<Iterable>::value) &&
-                                ((sizeof...(Iterables)==0) || !detail::are_iterators<Iterables...>::value) &&
-								(!hydra::detail::is_hydra_dense_histogram< typename std::remove_reference<Iterable>::type>::value) &&
-								(!hydra::detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) &&
-								detail::is_iterable<Iterable>::value && detail::are_iterables<Iterables...>::value ,
-	              LogLikelihoodFCN< Pdf<Functor,Integrator>,
+requires (
+	(!detail::Iterator<Iterable>) &&
+	((sizeof...(Iterables)==0) || !detail::Iterators<Iterables...>) &&
+	(!detail::is_hydra_dense_histogram<typename std::remove_reference<Iterable>::type>::value) &&
+	(!detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) &&
+	(detail::Iterable<Iterable>) &&
+	(detail::Iterables<Iterables...>)
+)
+inline LogLikelihoodFCN< Pdf<Functor,Integrator>,
 	                   decltype(std::declval<Iterable>().begin()),
-                       decltype(std::declval<Iterables>().begin())... >>::type
+                       decltype(std::declval<Iterables>().begin())... >
 make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Iterable&& points, Iterables&&... weights )
 {
 	return make_loglikehood_fcn(pdf,
@@ -180,11 +186,13 @@ make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Iterable&& points, Iter
 
 
 template< typename Functor, typename Integrator, typename Histogram>
-inline typename std::enable_if<detail::is_hydra_dense_histogram<Histogram>::value ||
-                               detail::is_hydra_sparse_histogram<Histogram>::value,
-LogLikelihoodFCN< Pdf<Functor,Integrator>,
+requires (
+	detail::is_hydra_dense_histogram<Histogram>::value ||
+	detail::is_hydra_sparse_histogram<Histogram>::value
+)
+inline LogLikelihoodFCN< Pdf<Functor,Integrator>,
 				  decltype(std::declval<const Histogram&>().GetBinsCenters().begin()),
-                  decltype( std::declval<const Histogram&>().GetBinsContents().begin())>>::type
+                  decltype( std::declval<const Histogram&>().GetBinsContents().begin())>
 make_loglikehood_fcn(Pdf<Functor,Integrator> const& pdf, Histogram const& points )
 {
 	return LogLikelihoodFCN< Pdf<Functor,Integrator>,

--- a/hydra/detail/LogLikelihoodFCN2.inl
+++ b/hydra/detail/LogLikelihoodFCN2.inl
@@ -34,6 +34,7 @@
 #include <hydra/detail/functors/LogLikelihood1.h>
 #include <hydra/detail/external/hydra_thrust/transform_reduce.h>
 #include <hydra/detail/external/hydra_thrust/inner_product.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -65,7 +66,8 @@ public:
 	}
 
 	template<size_t M = sizeof...(IteratorW)>
-	inline typename std::enable_if<(M==0), double >::type
+	requires ((M==0))
+	inline double
 	Eval( const std::vector<double>& parameters ) const{
 
 
@@ -105,7 +107,8 @@ public:
 	}
 
 	template<size_t M = sizeof...(IteratorW)>
-	inline typename std::enable_if<(M>0), double >::type
+	requires ((M>0))
+	inline double
 	Eval( const std::vector<double>& parameters ) const{
 
 		using   hydra::thrust::system::detail::generic::select_system;
@@ -147,8 +150,11 @@ public:
 
 
 template<typename... Pdfs,  typename Iterator, typename ...Iterators >
-inline typename std::enable_if< hydra::detail::is_iterator<Iterator>::value  && detail::are_iterators<Iterators...>::value,
-LogLikelihoodFCN< PDFSumExtendable<Pdfs...>, Iterator,Iterators...  >>::type
+requires (
+	detail::Iterator<Iterator> &&
+	detail::Iterators<Iterators...>
+)
+inline LogLikelihoodFCN< PDFSumExtendable<Pdfs...>, Iterator,Iterators...  >
 make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& functor, Iterator first, Iterator last, Iterators... weights )
 {
 	return LogLikelihoodFCN< PDFSumExtendable<Pdfs...>, Iterator, Iterators...>( functor, first, last, weights...);
@@ -156,14 +162,17 @@ make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& functor, Iterator first, I
 
 
 template<typename ...Pdfs, typename Iterable, typename ...Iterables >
-inline typename std::enable_if<   (!detail::is_iterator<Iterable>::value) &&
-                                  ((sizeof...(Iterables)==0) || !detail::are_iterators<Iterables...>::value) &&
-                                  (!hydra::detail::is_hydra_dense_histogram< typename std::remove_reference<Iterable>::type>::value) && //is not dense/sparse histogram
-		                          (!hydra::detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) &&
-								  detail::is_iterable<Iterable>::value && detail::are_iterables<Iterables...>::value  ,
-LogLikelihoodFCN< PDFSumExtendable<Pdfs...>,
+requires (
+	(!detail::Iterator<Iterable>) &&
+	((sizeof...(Iterables)==0) || !detail::Iterators<Iterables...>) &&
+	(!detail::is_hydra_dense_histogram< typename std::remove_reference<Iterable>::type>::value) &&
+	(!detail::is_hydra_sparse_histogram< typename std::remove_reference<Iterable>::type>::value) &&
+	(detail::Iterable<Iterable>) &&
+	(detail::Iterables<Iterables...>)
+)
+inline LogLikelihoodFCN< PDFSumExtendable<Pdfs...>,
                   decltype(std::declval<Iterable>().begin() ),
-                  decltype(std::declval<Iterables>().begin())... > >::type
+                  decltype(std::declval<Iterables>().begin())... >
 make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& functor, Iterable&& points, Iterables&&... weights ){
 
 	return make_loglikehood_fcn( functor,
@@ -173,11 +182,13 @@ make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& functor, Iterable&& points
 }
 
 template<typename ...Pdfs, typename Histogram>
-inline typename std::enable_if<detail::is_hydra_dense_histogram<Histogram>::value ||
-                               detail::is_hydra_sparse_histogram<Histogram>::value,
- LogLikelihoodFCN< PDFSumExtendable<Pdfs...>,
+requires (
+	detail::is_hydra_dense_histogram<Histogram>::value ||
+	detail::is_hydra_sparse_histogram<Histogram>::value
+)
+inline LogLikelihoodFCN< PDFSumExtendable<Pdfs...>,
                      decltype(std::declval<const Histogram&>().GetBinsCenters().begin()),
-                     decltype(std::declval<const Histogram&>().GetBinsContents().begin()) >>::type
+                     decltype(std::declval<const Histogram&>().GetBinsContents().begin()) >
 make_loglikehood_fcn(PDFSumExtendable<Pdfs...> const& functor, Histogram const&  points)
 {
 	return LogLikelihoodFCN< PDFSumExtendable<Pdfs...>,

--- a/hydra/detail/LogLikelihoodFCN3.inl
+++ b/hydra/detail/LogLikelihoodFCN3.inl
@@ -38,6 +38,7 @@
 #include <hydra/detail/external/hydra_thrust/inner_product.h>
 
 #include <utility>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -70,7 +71,8 @@ public:
 
 
 	template<size_t M = sizeof...(IteratorW)>
-	inline typename std::enable_if<(M==0), double >::type
+	requires ((M==0))
+	inline double
 	Eval( const std::vector<double>& parameters ) const{
 
 		using   hydra::thrust::system::detail::generic::select_system;
@@ -110,7 +112,8 @@ public:
 	}
 
 	template<size_t M = sizeof...(IteratorW)>
-	inline typename std::enable_if<(M>0), double >::type
+	requires ((M>0))
+	inline double
 	Eval( const std::vector<double>& parameters ) const{
 
 		using   hydra::thrust::system::detail::generic::select_system;
@@ -154,22 +157,25 @@ public:
 
 
 template<typename... Pdfs,  typename Iterator, typename ...Iterators >
-inline typename std::enable_if< hydra::detail::is_iterator<Iterator>::value && detail::are_iterators<Iterators...>::value,
-LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>, Iterator,Iterators...  >>::type
+requires (detail::Iterator<Iterator> && detail::Iterators<Iterators...>)
+inline LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>, Iterator,Iterators...  >
 make_loglikehood_fcn(PDFSumNonExtendable<Pdfs...>const& pdf, Iterator first, Iterator last, Iterators... weights)
 {
 	return LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>, Iterator,Iterators... >(pdf,first,last,weights...);
 }
 
 template<typename ...Pdfs, typename Iterable, typename ...Iterables>
-inline typename std::enable_if< (!detail::is_iterator<Iterable>::value) &&
-                                ((sizeof...(Iterables)==0) || !detail::are_iterators<Iterables...>::value) &&
-                                (!hydra::detail::is_hydra_dense_histogram<typename std::remove_reference<Iterable>::type>::value) &&
-								(!hydra::detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) &&
-								hydra::detail::is_iterable<Iterable>::value && detail::are_iterables<Iterables...>::value,
-LogLikelihoodFCN<  PDFSumNonExtendable<Pdfs...>,
+requires (
+	(!detail::Iterator<Iterable>) &&
+	((sizeof...(Iterables)==0) || !detail::Iterators<Iterables...>) &&
+	(!detail::is_hydra_dense_histogram<typename std::remove_reference<Iterable>::type>::value) &&
+	(!detail::is_hydra_sparse_histogram<typename std::remove_reference<Iterable>::type>::value) &&
+	(detail::Iterable<Iterable>) &&
+	(detail::Iterables<Iterables...>)
+)
+inline LogLikelihoodFCN<  PDFSumNonExtendable<Pdfs...>,
                      decltype(std::declval<Iterable>().begin()),
-                     decltype(std::declval<Iterables>().begin())... > >::type
+                     decltype(std::declval<Iterables>().begin())... >
 make_loglikehood_fcn(PDFSumNonExtendable<Pdfs...> const& functor, Iterable&& points, Iterables&&... weights )
 {
 	return make_loglikehood_fcn( functor,
@@ -179,11 +185,13 @@ make_loglikehood_fcn(PDFSumNonExtendable<Pdfs...> const& functor, Iterable&& poi
 }
 
 template<typename ...Pdfs, typename Histogram>
-inline typename std::enable_if<detail::is_hydra_dense_histogram<Histogram>::value ||
-                               detail::is_hydra_sparse_histogram<Histogram>::value,
- LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>,
+requires (
+	detail::is_hydra_dense_histogram<Histogram>::value ||
+	detail::is_hydra_sparse_histogram<Histogram>::value
+)
+inline LogLikelihoodFCN< PDFSumNonExtendable<Pdfs...>,
                      decltype(std::declval<const Histogram&>().GetBinsCenters().begin()),
-                     decltype(std::declval<const Histogram&>().GetBinsContents().begin()) >>::type
+                     decltype(std::declval<const Histogram&>().GetBinsContents().begin()) >
 make_loglikehood_fcn(PDFSumNonExtendable<Pdfs...> const& functor, Histogram const&  points)
 {
 

--- a/hydra/detail/Minus.h
+++ b/hydra/detail/Minus.h
@@ -45,6 +45,7 @@
 #include <hydra/Complex.h>
 #include <hydra/Parameter.h>
 #include <hydra/detail/FunctorTraits.h>
+#include <hydra/detail/FunctorConcepts.h>
 #include <hydra/Parameter.h>
 #include <hydra/Tuple.h>
 #include <hydra/detail/BaseCompositeFunctor.h>
@@ -120,50 +121,40 @@ hydra::thrust::tuple<F1, F2>,
 
 // + operator two functors
 template<typename T1, typename T2>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T1>::value || detail::is_hydra_lambda<T1>::value ) &&
-(detail::is_hydra_functor<T2>::value || detail::is_hydra_lambda<T2>::value ),
-Minus<T1, T2> >::type
+requires (detail::HydraCallable<T1> && detail::HydraCallable<T2>)
+inline Minus<T1, T2>
 operator-(T1 const& F1, T2 const& F2)
 {
 	return  Minus<T1,T2>(F1, F2);
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value  ) &&
-(std::is_arithmetic<U>::value),
-Minus< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Minus< Constant<U>, T>
 operator-(U const cte, T const& F)
 {
 	return  Constant<U>(cte)-F;
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Minus< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Minus< Constant<U>, T>
 operator-( T const& F, U cte)
 {
 	return  F-Constant<U>(cte);
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Minus< Constant<hydra::complex<U>>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Minus< Constant<hydra::complex<U>>, T>
 operator-(hydra::complex<U> const& cte, T const& F)
 {
 	return  Constant<hydra::complex<U> >(cte)-F;
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Minus< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Minus< Constant<U>, T>
 operator-( T const& F, hydra::complex<U> const& cte)
 {
 	return  F-Constant<hydra::complex<U> >(cte);
@@ -171,10 +162,8 @@ operator-( T const& F, hydra::complex<U> const& cte)
 
 // Convenience function
 template <typename F1, typename F2>
-inline typename std::enable_if<
-(detail::is_hydra_functor<F1>::value || detail::is_hydra_lambda<F1>::value ) &&
-(detail::is_hydra_functor<F2>::value || detail::is_hydra_lambda<F2>::value ),
-Minus<F1, F2>>::type
+requires (detail::HydraCallable<F1> && detail::HydraCallable<F2>)
+inline Minus<F1, F2>
 minus(F1 const& f1, F2 const& f2)
 {
 	return  Minus<F1, F2>(f1,f2);

--- a/hydra/detail/Multiply.h
+++ b/hydra/detail/Multiply.h
@@ -49,6 +49,7 @@
 #include <hydra/Parameter.h>
 #include <hydra/detail/CompositeTraits.h>
 #include <hydra/detail/FunctorTraits.h>
+#include <hydra/detail/FunctorConcepts.h>
 #include <hydra/Parameter.h>
 #include <hydra/Tuple.h>
 #include <hydra/detail/BaseCompositeFunctor.h>
@@ -134,50 +135,40 @@ hydra::thrust::tuple<F1, F2, Fs...>,
 
 // multiplication: * operator two functors
 template<typename T1, typename T2>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T1>::value || detail::is_hydra_lambda<T1>::value ) &&
-(detail::is_hydra_functor<T2>::value || detail::is_hydra_lambda<T2>::value ),
-Multiply<T1, T2> >::type
+requires (detail::HydraCallable<T1> && detail::HydraCallable<T2>)
+inline Multiply<T1, T2>
 operator*(T1 const& F1, T2 const& F2)
 {
 	return  Multiply<T1,T2>(F1, F2);
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Multiply< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Multiply< Constant<U>, T>
 operator*(U const cte, T const& F)
 {
 	return  Constant<U>(cte)*F;
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Multiply< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Multiply< Constant<U>, T>
 operator*( T const& F, U cte)
 {
 	return  Constant<U>(cte)*F;
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Multiply< Constant<hydra::complex<U>>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Multiply< Constant<hydra::complex<U>>, T>
 operator*(hydra::complex<U> const& cte, T const& F)
 {
 	return  Constant<hydra::complex<U> >(cte)*F;
 }
 
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Multiply< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && (std::is_arithmetic_v<U>))
+inline Multiply< Constant<U>, T>
 operator*( T const& F, hydra::complex<U> const& cte)
 {
 	return  Constant<hydra::complex<U> >(cte)*F;
@@ -186,12 +177,8 @@ operator*( T const& F, hydra::complex<U> const& cte)
 // Convenience function
 // Convenience function
 template <typename F1, typename F2, typename ...Fs>
-inline typename std::enable_if<
-(detail::is_hydra_functor<F1>::value || detail::is_hydra_lambda<F1>::value ) &&
-(detail::is_hydra_functor<F2>::value || detail::is_hydra_lambda<F2>::value ) &&
-detail::all_true<
-(detail::is_hydra_functor<Fs>::value || detail::is_hydra_lambda<Fs>::value )...>::value,
-Multiply<F1, F2,Fs...>>::type
+requires (detail::HydraCallable<F1> && detail::HydraCallable<F2> && (detail::HydraCallable<Fs> && ...))
+inline Multiply<F1, F2,Fs...>
 multiply(F1 const& f1, F2 const& f2, Fs const&... functors )
 {
 	return  Multiply<F1, F2,Fs... >(f1,f2, functors ... );

--- a/hydra/detail/Parameters.h
+++ b/hydra/detail/Parameters.h
@@ -39,6 +39,7 @@
 #include <hydra/detail/Hash.h>
 #include <cassert>
 #include <cstddef>
+#include <concepts>
 
 namespace hydra {
 
@@ -174,8 +175,8 @@ public:
 		return &fParameters[0];
 	}
 
-	template<typename Int,
-			typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	__hydra_host__ __hydra_device__ inline
 	const hydra::Parameter& GetParameter(Int i) const {
 		return fParameters[i];
@@ -192,8 +193,8 @@ public:
 		return fParameters[i] ;
 	}
 
-	template<typename Int,
-		typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	__hydra_host__ __hydra_device__ inline
 	hydra::Parameter& Parameter(Int i) {
 		return fParameters[i];
@@ -210,8 +211,8 @@ public:
 		return fParameters[i] ;
 	}
 
-	template<typename Int,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	__hydra_host__ __hydra_device__ inline
 	void SetParameter(Int i, hydra::Parameter const& value) {
 		fParameters[i]=value;
@@ -223,8 +224,8 @@ public:
 #endif
 	}
 
-	template<typename Int,
-		typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	__hydra_host__ __hydra_device__ inline
 	void SetParameter(Int i, double value) {
 		fParameters[i]=value;
@@ -263,8 +264,8 @@ public:
 		Update();
 	}
 
-	template<typename Int,
-		typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	__hydra_host__ __hydra_device__  inline
 	GReal_t operator[](Int i) const {
 		return (GReal_t ) fParameters[i];

--- a/hydra/detail/ParametersCompositeFunctor.h
+++ b/hydra/detail/ParametersCompositeFunctor.h
@@ -40,6 +40,7 @@
 #include <hydra/detail/Constant.h>
 #include <hydra/Parameter.h>
 #include <hydra/Placeholders.h>
+#include <concepts>
 
 namespace hydra {
 
@@ -119,8 +120,8 @@ public:
 
 	}
 
-	template<typename Int,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline const hydra::Parameter& GetParameter(Int i) const {
 
 		std::vector<hydra::Parameter*> _parameters;
@@ -143,8 +144,8 @@ public:
 		return *(_parameters[i]) ;
 	}
 
-	template<typename Int,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline hydra::Parameter& Parameter(Int i) {
 
 		std::vector<hydra::Parameter*> _parameters;
@@ -167,8 +168,8 @@ public:
 	}
 
 
-	template<typename Int,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline void SetParameter(Int i, hydra::Parameter const& value) {
 
 		std::vector<hydra::Parameter*> _parameters;
@@ -177,8 +178,8 @@ public:
 		*(_parameters[i])=value;
 	}
 
-	template<typename Int,
-	typename = typename std::enable_if<std::is_integral<Int>::value, void>::type>
+	template<typename Int>
+	requires (std::integral<Int>)
 	inline void SetParameter(Int i, double value) {
 		std::vector<hydra::Parameter*> _parameters;
 		detail::add_parameters_in_tuple(_parameters, fFtorTuple );

--- a/hydra/detail/PhaseSpace.inl
+++ b/hydra/detail/PhaseSpace.inl
@@ -35,6 +35,7 @@
 #define _PHASESPACE_INL_
 
 #include <hydra/detail/utility/Exception.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -313,8 +314,8 @@ void PhaseSpace<N,GRND>::Evaluate( IteratorMother mbegin,
 
 template <size_t N, typename GRND>
 template<typename ...FUNCTOR, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+requires (detail::Iterable<Iterable>)
+inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 PhaseSpace<N,GRND>::Evaluate(Vector4R const& mother, Iterable&& result,
 		FUNCTOR const& ...functors) {
 
@@ -330,9 +331,8 @@ PhaseSpace<N,GRND>::Evaluate(Vector4R const& mother, Iterable&& result,
 
 template <size_t N, typename GRND>
 template<typename ...FUNCTOR, typename IterableMother, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value &&
-	hydra::detail::is_iterable<IterableMother>::value,
-				 hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+requires (detail::Iterable<Iterable> && detail::Iterable<IterableMother>)
+inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 PhaseSpace<N,GRND>::Evaluate( IterableMother&& mothers, Iterable&& result, FUNCTOR const& ...functors) {
 
 
@@ -376,8 +376,8 @@ void PhaseSpace<N,GRND>::Generate( Iterator1 begin, Iterator1 end, Iterator2 dau
 
 template <size_t N, typename GRND>
 template<typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-				 hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+requires (detail::Iterable<Iterable>)
+inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 PhaseSpace<N,GRND>::Generate(Vector4R const& mother, Iterable&& events){
 	/**
 	 * Run the generator and calculate the maximum weight. It takes as input the fourvector of the mother particle
@@ -395,9 +395,8 @@ PhaseSpace<N,GRND>::Generate(Vector4R const& mother, Iterable&& events){
 
 template <size_t N, typename GRND>
 template<typename IterableMothers, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value &&
-		hydra::detail::is_iterable<IterableMothers>::value,
-					 hydra::Range<decltype(std::declval<Iterable>().begin())>>::type
+requires (detail::Iterable<Iterable> && detail::Iterable<IterableMothers>)
+inline hydra::Range<decltype(std::declval<Iterable>().begin())>
 PhaseSpace<N,GRND>::Generate( IterableMothers&& mothers, Iterable&& daughters){
 	/**
 	 * Run the generator and calculate the maximum weight. It takes as input the device vector with the four-vectors of the mother particle

--- a/hydra/detail/QuasiRandomBase.h
+++ b/hydra/detail/QuasiRandomBase.h
@@ -125,9 +125,8 @@ public:
 
 	//!Fills a range with quasi-random values.
 	template<typename ...T>
-	 __hydra_host__ __hydra_device__
-	inline typename std::enable_if<
-	sizeof...(T)==LatticeT::lattice_dimension, void>::type
+	requires (sizeof...(T)==LatticeT::lattice_dimension)
+	__hydra_host__ __hydra_device__ inline void
 	generate(hydra::tuple<T...>& data){
 		generate_helper(data);
 	}
@@ -227,13 +226,13 @@ protected:
 private:
 
 	 template<typename T, unsigned I>
-	 __hydra_host__ __hydra_device__
-	 inline typename std::enable_if< (I== LatticeT::lattice_dimension), void>::type
+	 requires ((I== LatticeT::lattice_dimension))
+	 __hydra_host__ __hydra_device__ inline void
 	 generate_helper(T& ){ }
 
 	 template<typename T, unsigned I=0>
-	 __hydra_host__ __hydra_device__
-	 inline typename std::enable_if< (I< LatticeT::lattice_dimension), void>::type
+	 requires ((I< LatticeT::lattice_dimension))
+	 __hydra_host__ __hydra_device__ inline void
 	 generate_helper(T& data){
 		 hydra::get<I>(data)=this->operator()();
 		 generate_helper<T,I+1>(data);

--- a/hydra/detail/Random.inl
+++ b/hydra/detail/Random.inl
@@ -40,10 +40,11 @@
 namespace hydra{
 
 template<typename RNG, typename DerivedPolicy, typename IteratorData, typename IteratorWeight>
-typename std::enable_if<
-	detail::random::is_iterator<IteratorData>::value && detail::random::is_iterator<IteratorWeight>::value,
-	Range<IteratorData>
->::type
+requires (
+	detail::random::Iterator<IteratorData> &&
+	detail::random::Iterator<IteratorWeight>
+)
+Range<IteratorData>
 unweight( hydra::thrust::detail::execution_policy_base<DerivedPolicy> const& policy, IteratorData data_begin, IteratorData data_end, IteratorWeight weights_begin,
 		double max_pdf, size_t rng_seed, size_t rng_jump)
 {
@@ -70,10 +71,11 @@ unweight( hydra::thrust::detail::execution_policy_base<DerivedPolicy> const& pol
 
 
 template<typename RNG, typename IteratorData, typename IteratorWeight, hydra::detail::Backend BACKEND>
-typename std::enable_if<
-	detail::random::is_iterator<IteratorData>::value && detail::random::is_iterator<IteratorWeight>::value,
-	Range<IteratorData>
->::type
+requires (
+	detail::random::Iterator<IteratorData> &&
+	detail::random::Iterator<IteratorWeight>
+)
+Range<IteratorData>
 unweight( detail::BackendPolicy<BACKEND> const& policy, IteratorData data_begin, IteratorData data_end, IteratorWeight weights_begin,
 		double max_pdf, size_t rng_seed, size_t rng_jump)
 {
@@ -83,9 +85,11 @@ unweight( detail::BackendPolicy<BACKEND> const& policy, IteratorData data_begin,
 }
 
 template< typename RNG, typename IteratorData, typename IteratorWeight>
-typename std::enable_if<
-detail::random::is_iterator<IteratorData>::value && detail::random::is_iterator<IteratorWeight>::value,
-Range<IteratorData> >::type
+requires (
+	detail::random::Iterator<IteratorData> &&
+	detail::random::Iterator<IteratorWeight>
+)
+Range<IteratorData>
 unweight(IteratorData data_begin, IteratorData data_end , IteratorWeight weights_begin,
 		double max_pdf, size_t rng_seed, size_t rng_jump)
 {
@@ -102,9 +106,11 @@ unweight(IteratorData data_begin, IteratorData data_end , IteratorWeight weights
 }
 
 template<typename RNG, typename IterableData, typename IterableWeight, hydra::detail::Backend  BACKEND>
-typename std::enable_if<
-detail::random::is_iterable<IterableData>::value && detail::random::is_iterable<IterableWeight>::value,
-Range< decltype(std::declval<IterableData>().begin())> >::type
+requires (
+	detail::random::Iterable<IterableData> &&
+	detail::random::Iterable<IterableWeight>
+)
+Range< decltype(std::declval<IterableData>().begin())>
 unweight( hydra::detail::BackendPolicy<BACKEND> const& policy,  IterableData&& data, IterableWeight&& weights,
 		double max_pdf, size_t rng_seed, size_t rng_jump)
 {
@@ -113,8 +119,11 @@ unweight( hydra::detail::BackendPolicy<BACKEND> const& policy,  IterableData&& d
 }
 
 template< typename RNG, typename IterableData, typename IterableWeight>
-typename std::enable_if<detail::random::is_iterable<IterableData>::value && detail::random::is_iterable<IterableWeight>::value,
-Range< decltype(std::declval<IterableData>().begin())>>::type
+requires (
+	detail::random::Iterable<IterableData> &&
+	detail::random::Iterable<IterableWeight>
+)
+Range< decltype(std::declval<IterableData>().begin())>
 unweight( IterableData&&  data, IterableWeight&&  weights,
 		double max_pdf, size_t rng_seed, size_t rng_jump)
 {
@@ -134,10 +143,11 @@ unweight( IterableData&&  data, IterableWeight&&  weights,
 
 
 template< typename RNG, typename Functor, typename Iterator, typename DerivedPolicy>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-	Range<Iterator>
->::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator>
+)
+Range<Iterator>
 unweight(hydra::thrust::detail::execution_policy_base<DerivedPolicy>  const& policy, Iterator begin, Iterator end, Functor const& functor,
 		double max_pdf, size_t rng_seed, size_t rng_jump)
 {
@@ -174,10 +184,11 @@ unweight(hydra::thrust::detail::execution_policy_base<DerivedPolicy>  const& pol
 
 
 template< typename RNG, typename Functor, typename Iterator, hydra::detail::Backend  BACKEND>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-	Range<Iterator>
->::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator>
+)
+Range<Iterator>
 unweight( detail::BackendPolicy<BACKEND> const& policy, Iterator begin, Iterator end, Functor const& functor,
 		double max_pdf, size_t rng_seed, size_t rng_jump)
 {
@@ -187,10 +198,11 @@ unweight( detail::BackendPolicy<BACKEND> const& policy, Iterator begin, Iterator
 }
 
 template<typename RNG, typename Functor, typename Iterator>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-	Range<Iterator>
->::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator>
+)
+Range<Iterator>
 unweight( Iterator begin, Iterator end, Functor const& functor, double max_pdf, size_t rng_seed, size_t rng_jump)
 {
 	typedef  typename hydra::thrust::iterator_system< Iterator>::type   system_data_type;
@@ -199,10 +211,11 @@ unweight( Iterator begin, Iterator end, Functor const& functor, double max_pdf, 
 
 
 template<typename RNG, typename Functor, typename Iterable, hydra::detail::Backend  BACKEND>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterable<Iterable>::value ,
-	Range< decltype(std::declval<Iterable>().begin())>
->::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterable<Iterable>
+)
+Range< decltype(std::declval<Iterable>().begin())>
 unweight( hydra::detail::BackendPolicy<BACKEND> const& policy, Iterable&& iterable, Functor const& functor,
 		double max_pdf, size_t rng_seed, size_t rng_jump)
 {
@@ -212,10 +225,11 @@ unweight( hydra::detail::BackendPolicy<BACKEND> const& policy, Iterable&& iterab
 }
 
 template<typename RNG, typename Functor, typename Iterable>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterable<Iterable>::value ,
-	Range< decltype(std::declval<Iterable>().begin())>
->::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterable<Iterable>
+)
+Range< decltype(std::declval<Iterable>().begin())>
 unweight( Iterable&& iterable, Functor const& functor, double max_pdf, size_t rng_seed, size_t rng_jump)
 {
 
@@ -227,9 +241,11 @@ unweight( Iterable&& iterable, Functor const& functor, double max_pdf, size_t rn
 //
 //---------------------------------------------------------------
 template<typename RNG, typename DerivedPolicy, typename Functor, typename Iterator>
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-	Range<Iterator> >::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator>
+)
+Range<Iterator>
 sample(hydra::thrust::detail::execution_policy_base<DerivedPolicy> const& policy, Iterator begin, Iterator end, double min, double max,
 				Functor const& functor, size_t seed, size_t rng_jump)
 {
@@ -271,9 +287,11 @@ sample(hydra::thrust::detail::execution_policy_base<DerivedPolicy> const& policy
 }
 
 template<typename RNG, typename Functor, typename Iterator, hydra::detail::Backend  BACKEND>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-Range<Iterator> >::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator>
+)
+Range<Iterator>
 sample(hydra::detail::BackendPolicy<BACKEND> const& policy,
 		Iterator begin, Iterator end, double min, double max,
 		Functor const& functor, size_t seed, size_t rng_jump)
@@ -283,9 +301,11 @@ sample(hydra::detail::BackendPolicy<BACKEND> const& policy,
 }
 
 template<typename RNG, typename Functor, typename Iterator>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-Range<Iterator> >::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator>
+)
+Range<Iterator>
 sample(Iterator begin, Iterator end , double min, double max,
 		Functor const& functor, size_t seed, size_t rng_jump)
 {
@@ -296,9 +316,11 @@ sample(Iterator begin, Iterator end , double min, double max,
 }
 
 template<typename RNG, typename Functor, typename Iterable>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterable<Iterable>::value ,
-Range< decltype(std::declval<Iterable>().begin())>>::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterable<Iterable>
+)
+Range< decltype(std::declval<Iterable>().begin())>
 sample(Iterable&& output, double min, double max, Functor const& functor, size_t seed, size_t rng_jump)
 {
 	return	sample<RNG>(std::forward<Iterable>(output).begin(), std::forward<Iterable>(output).end(),
@@ -307,10 +329,11 @@ sample(Iterable&& output, double min, double max, Functor const& functor, size_t
 
 
 template<typename RNG, typename DerivedPolicy, typename Functor, typename Iterator, size_t N >
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-	Range<Iterator>
->::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator>
+)
+Range<Iterator>
 sample( hydra::thrust::detail::execution_policy_base<DerivedPolicy>  const& policy,
 		Iterator begin, Iterator end ,
 		std::array<double,N> const& min, std::array<double,N> const& max,
@@ -351,9 +374,11 @@ sample( hydra::thrust::detail::execution_policy_base<DerivedPolicy>  const& poli
 }
 
 template<typename RNG, typename Functor, typename Iterator, hydra::detail::Backend  BACKEND, size_t N >
-typename std::enable_if<
-detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-Range<Iterator> >::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator>
+)
+Range<Iterator>
 sample(hydra::detail::BackendPolicy<BACKEND> const& policy,
 		Iterator begin, Iterator end ,
 		std::array<double,N>const& min,	std::array<double,N>const& max,
@@ -364,10 +389,11 @@ sample(hydra::detail::BackendPolicy<BACKEND> const& policy,
 }
 
 template<typename RNG, typename Functor, typename Iterator, size_t N >
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterator<Iterator>::value,
-	Range<Iterator>
->::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator>
+)
+Range<Iterator>
 sample(Iterator begin, Iterator end , std::array<double,N>const& min, std::array<double,N>const& max,
 		Functor const& functor, size_t seed, size_t rng_jump)
 {
@@ -379,11 +405,12 @@ sample(Iterator begin, Iterator end , std::array<double,N>const& min, std::array
 
 
 template<typename RNG, typename Functor, typename Iterator>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value  &&
-detail::random::is_iterator<Iterator>::value &&
-detail::is_tuple_type< decltype(*std::declval<Iterator>())>::value,
-Range<Iterator> >::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterator<Iterator> &&
+	detail::is_tuple_type< decltype(*std::declval<Iterator>())>::value
+)
+Range<Iterator>
 sample(Iterator begin, Iterator end ,
 		typename Functor::argument_type const& min, typename Functor::argument_type const& max,
 		Functor const& functor, size_t seed, size_t rng_jump)
@@ -400,10 +427,11 @@ sample(Iterator begin, Iterator end ,
 }
 
 template<typename RNG, typename Functor, typename Iterable, size_t N >
-typename std::enable_if<
-	detail::random::is_callable<Functor>::value && detail::random::is_iterable<Iterable>::value ,
-	Range< decltype(std::declval<Iterable>().begin())>
->::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterable<Iterable>
+)
+Range< decltype(std::declval<Iterable>().begin())>
 sample(Iterable&& output , std::array<double,N>const& min, std::array<double,N>const& max,
 		Functor const& functor, size_t seed, size_t rng_jump)
 {
@@ -412,11 +440,12 @@ sample(Iterable&& output , std::array<double,N>const& min, std::array<double,N>c
 }
 
 template<typename RNG, typename Functor, typename Iterable>
-typename std::enable_if<
-detail::random::is_callable<Functor>::value  &&
-detail::random::is_iterable<Iterable>::value &&
-detail::is_tuple_type< decltype(*std::declval<Iterable>().begin())>::value ,
-Range< decltype(std::declval<Iterable>().begin())>>::type
+requires (
+	detail::random::Callable<Functor> &&
+	detail::random::Iterable<Iterable> &&
+	detail::is_tuple_type< decltype(*std::declval<Iterable>().begin())>::value
+)
+Range< decltype(std::declval<Iterable>().begin())>
 sample( Iterable&& output ,
 		typename Functor::argument_type const& min,typename Functor::argument_type  const& max,
 		Functor const& functor, size_t seed, size_t rng_jump)

--- a/hydra/detail/RandomConcepts.h
+++ b/hydra/detail/RandomConcepts.h
@@ -1,0 +1,59 @@
+/*----------------------------------------------------------------------------
+ *
+ *   Copyright (C) 2016 - 2023 Antonio Augusto Alves Junior
+ *
+ *   This file is part of Hydra Data Analysis Framework.
+ *
+ *   Hydra is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Hydra is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Hydra.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *---------------------------------------------------------------------------*/
+
+/*
+ * RandomConcepts.h
+ *
+ *  Created on: 14/03/2025
+ *      Author: Davide Brundu
+ */
+
+#ifndef RANDOMCONCEPTS_H_
+#define RANDOMCONCEPTS_H_
+
+#include <concepts>
+#include <type_traits>
+
+namespace hydra {
+
+namespace detail {
+
+template <typename T>
+concept HasRngFormula = has_rng_formula<T>::value;
+
+template <typename FUNCTOR, typename Engine, typename Iterator>
+concept IsRngFormulaConvertible = requires (Engine& engine, const FUNCTOR& functor) {
+    { RngFormula<FUNCTOR>().Generate(engine, functor) } -> std::convertible_to<typename hydra::thrust::iterator_traits<Iterator>::value_type>;
+};
+
+template <typename FUNCTOR, typename Engine, typename Iterator>
+concept NotConvertibleToIteratorValue =
+    !std::convertible_to<
+        decltype(RngFormula<FUNCTOR>().Generate(std::declval<Engine&>(), std::declval<const FUNCTOR&>())),
+        typename std::iterator_traits<Iterator>::value_type>;
+
+}  // namespace detail
+
+}  // namespace hydra
+
+
+
+#endif /* RANDOMCONCEPTS_H_ */

--- a/hydra/detail/RandomConcepts.h
+++ b/hydra/detail/RandomConcepts.h
@@ -32,6 +32,11 @@
 #include <concepts>
 #include <type_traits>
 
+#include <hydra/detail/FormulaTraits.h>
+#include <hydra/detail/RngFormula.h>
+#include <hydra/detail/RandomIteratorTraits.h>
+#include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
+
 namespace hydra {
 
 namespace detail {
@@ -49,6 +54,38 @@ concept NotConvertibleToIteratorValue =
     !std::convertible_to<
         decltype(RngFormula<FUNCTOR>().Generate(std::declval<Engine&>(), std::declval<const FUNCTOR&>())),
         typename std::iterator_traits<Iterator>::value_type>;
+
+namespace random {
+
+/**
+ * @brief Satisfied when @c T is accepted as an iterator argument by the random
+ * generation/sampling overloads (see hydra::detail::random::is_iterator).
+ */
+template <typename T>
+concept Iterator = is_iterator<T>::value;
+
+/**
+ * @brief Satisfied when @c T is accepted as an iterable argument by the random
+ * generation/sampling overloads (see hydra::detail::random::is_iterable).
+ */
+template <typename T>
+concept Iterable = is_iterable<T>::value;
+
+/**
+ * @brief Satisfied when @c T is a callable (functor/lambda) accepted by the
+ * random generation/sampling overloads (see hydra::detail::random::is_callable).
+ */
+template <typename T>
+concept Callable = is_callable<T>::value;
+
+/**
+ * @brief Satisfied when @c Functor has an RngFormula whose result is convertible
+ * to @c Iterable's value type (see hydra::detail::random::is_matching_iterable).
+ */
+template <typename Engine, typename Functor, typename Iterable>
+concept MatchingIterable = is_matching_iterable<Engine, Functor, Iterable>::value;
+
+}  // namespace random
 
 }  // namespace detail
 

--- a/hydra/detail/RandomFill.inl
+++ b/hydra/detail/RandomFill.inl
@@ -90,7 +90,8 @@ namespace hydra{
      * @param functor distribution to be sampled
      */
     template< typename Engine, hydra::detail::Backend BACKEND, typename Iterable, typename FUNCTOR >
-    typename std::enable_if< detail::random::is_matching_iterable<Engine, FUNCTOR, Iterable>::value, void>::type
+    requires (detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+    void
     fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
                 Iterable&& iterable, FUNCTOR const& functor, size_t seed, size_t rng_jump){
 
@@ -105,8 +106,8 @@ namespace hydra{
      * @param functor distribution to be sampled
      */
     template< typename Engine, typename Iterable, typename FUNCTOR >
-    typename std::enable_if< detail::random::is_matching_iterable<Engine, FUNCTOR, Iterable>::value,
-     void>::type
+    requires (detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+    void
     fill_random(Iterable&& iterable, FUNCTOR const& functor, size_t seed, size_t rng_jump){
 
         fill_random(std::forward<Iterable>(iterable).begin(),
@@ -174,7 +175,8 @@ namespace hydra{
      * @brief Fall back function if the argument is not an Iterable or if it is not convertible to the Functor return value
      */
     template< typename Engine, hydra::detail::Backend BACKEND, typename Iterable, typename FUNCTOR >
-    typename std::enable_if< !(detail::random::is_matching_iterable<Engine, FUNCTOR, Iterable>::value), void>::type
+    requires (!detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+    void
     fill_random(hydra::detail::BackendPolicy<BACKEND> const& policy,
                 Iterable&& iterable, FUNCTOR const& functor, size_t seed, size_t rng_jump)
     {
@@ -188,7 +190,8 @@ namespace hydra{
      * @brief Fall back function if the argument is not an Iterable or if it is not convertible to the Functor return value
      */
     template< typename Engine, typename Iterable, typename FUNCTOR >
-    typename std::enable_if<!detail::random::is_matching_iterable<Engine, FUNCTOR, Iterable>::value, void>::type
+    requires (!detail::random::MatchingIterable<Engine, FUNCTOR, Iterable>)
+    void
     fill_random(Iterable&& iterable, FUNCTOR const& functor, size_t seed, size_t rng_jump)
     {
         HYDRA_STATIC_ASSERT( int(std::is_class<Engine>::value) ==-1 ,

--- a/hydra/detail/RandomIteratorTraits.h
+++ b/hydra/detail/RandomIteratorTraits.h
@@ -1,0 +1,103 @@
+/*----------------------------------------------------------------------------
+ *
+ *   Copyright (C) 2016 - 2023 Antonio Augusto Alves Junior
+ *
+ *   This file is part of Hydra Data Analysis Framework.
+ *
+ *   Hydra is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Hydra is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Hydra.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *---------------------------------------------------------------------------*/
+
+/*
+ * RandomIteratorTraits.h
+ *
+ *  Created on: 29/06/2026
+ *      Author: Davide Brundu
+ *
+ *  Type traits used to classify the arguments accepted by the random
+ *  generation/sampling overloads (an iterator, an iterable, a callable, or a
+ *  functor whose RngFormula matches an iterable's value type). Kept separate
+ *  from the engine-level hydra/detail/RandomTraits.h.
+ */
+
+#ifndef RANDOMITERATORTRAITS_H_
+#define RANDOMITERATORTRAITS_H_
+
+#include <type_traits>
+
+#include <hydra/detail/TypeTraits.h>
+#include <hydra/detail/Iterable_traits.h>
+#include <hydra/detail/FunctorTraits.h>
+#include <hydra/detail/CompositeTraits.h>
+#include <hydra/detail/FormulaTraits.h>
+#include <hydra/detail/RngFormula.h>
+#include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
+
+namespace hydra {
+
+namespace detail {
+
+namespace random {
+
+template<typename T>
+struct is_iterator: std::conditional<
+        !hydra::detail::is_hydra_composite_functor<T>::value &&
+		!hydra::detail::is_hydra_functor<T>::value &&
+		!hydra::detail::is_hydra_lambda<T>::value &&
+		!hydra::detail::is_iterable<T>::value &&
+		 hydra::detail::is_iterator<T>::value,
+         std::true_type,
+         std::false_type >::type {};
+
+template<typename T>
+struct is_iterable: std::conditional<
+        !hydra::detail::is_hydra_composite_functor<T>::value &&
+		!hydra::detail::is_hydra_functor<T>::value &&
+		!hydra::detail::is_hydra_lambda<T>::value  &&
+		 hydra::detail::is_iterable<T>::value &&
+		!hydra::detail::is_iterator<T>::value,
+         std::true_type,
+         std::false_type >::type {};
+
+template<typename T>
+struct is_callable: std::conditional<
+        (hydra::detail::is_hydra_composite_functor<T>::value ||
+         hydra::detail::is_hydra_functor<T>::value ||
+         hydra::detail::is_hydra_lambda<T>::value ) &&
+        !hydra::detail::is_iterable<T>::value &&
+        !hydra::detail::is_iterator<T>::value,
+         std::true_type,
+         std::false_type >::type {};
+
+template< typename Engine, typename Functor, typename Iterable>
+struct is_matching_iterable: std::conditional<
+     hydra::detail::is_iterable<Iterable>::value &&
+    !hydra::detail::is_iterator<Iterable>::value &&
+    (hydra::detail::is_hydra_composite_functor<Functor>::value ||
+     hydra::detail::is_hydra_functor<Functor>::value ||
+     hydra::detail::is_hydra_lambda<Functor>::value  ) &&
+     hydra::detail::has_rng_formula<Functor>::value &&
+     std::is_convertible<
+    decltype(std::declval<RngFormula<Functor>>().Generate( std::declval<Engine&>(), std::declval<Functor const&>())),
+    typename hydra::thrust::iterator_traits<decltype(std::declval<Iterable>().begin())>::value_type>::value,
+    std::true_type,  std::false_type
+>::type{};
+
+}  // namespace random
+
+}  // namespace detail
+
+}  // namespace hydra
+
+#endif /* RANDOMITERATORTRAITS_H_ */

--- a/hydra/detail/Range1.inl
+++ b/hydra/detail/Range1.inl
@@ -36,6 +36,7 @@
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
 
 #include <utility>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -155,8 +156,8 @@ make_reverse_range(Iterator begin, Iterator end ){
 }
 
 template<typename Iterable>
-typename std::enable_if<hydra::detail::is_iterable<Iterable>::value,
-Range<decltype(std::declval<Iterable>().begin())>>::type
+requires (detail::Iterable<Iterable>)
+Range<decltype(std::declval<Iterable>().begin())>
 make_range(Iterable const& container){
 
 	typedef decltype(hydra::begin(container)) iterator_type;
@@ -164,8 +165,8 @@ make_range(Iterable const& container){
 }
 
 template<typename Iterable>
-typename std::enable_if<hydra::detail::is_iterable<Iterable>::value,
-Range<decltype(std::declval<Iterable>().begin())>>::type
+requires (detail::Iterable<Iterable>)
+Range<decltype(std::declval<Iterable>().begin())>
 make_range(Iterable&& container){
 
 	typedef decltype(hydra::begin(std::forward<Iterable>(container))) iterator_type;
@@ -174,8 +175,8 @@ make_range(Iterable&& container){
 }
 
 template<typename Iterable>
-typename std::enable_if<hydra::detail::is_reverse_iterable<Iterable>::value,
-Range<decltype(std::declval<Iterable>().rbegin())>>::type
+requires (detail::ReverseIterable<Iterable>)
+Range<decltype(std::declval<Iterable>().rbegin())>
 make_reverse_range(Iterable const& container){
 
 	typedef decltype(hydra::rbegin(container)) iterator_type;
@@ -183,8 +184,8 @@ make_reverse_range(Iterable const& container){
 }
 
 template<typename Iterable>
-typename std::enable_if<hydra::detail::is_reverse_iterable<Iterable>::value,
-Range<decltype(std::declval<Iterable>().rbegin())>>::type
+requires (detail::ReverseIterable<Iterable>)
+Range<decltype(std::declval<Iterable>().rbegin())>
 make_reverse_range(Iterable&& container){
 
 	typedef decltype(hydra::rbegin(std::forward<Iterable>(container))) iterator_type;

--- a/hydra/detail/Range2.inl
+++ b/hydra/detail/Range2.inl
@@ -35,6 +35,8 @@
 #include <hydra/detail/external/hydra_thrust/iterator/transform_iterator.h>
 #include <hydra/detail/FunctorTraits.h>
 #include <utility>
+#include <hydra/detail/IteratorConcepts.h>
+#include <hydra/detail/FunctorConcepts.h>
 
 namespace hydra {
 
@@ -138,15 +140,15 @@ private:
 };
 
 template<typename Iterator, typename Functor>
-typename hydra::thrust::detail::enable_if< detail::is_hydra_functor<Functor>::value , Range<Iterator, Functor> >::type
+requires (detail::HydraFunctor<Functor>)
+Range<Iterator, Functor>
 make_range(Iterator begin, Iterator end, Functor const& functor ){
 	return Range<Iterator, Functor>( begin, end, functor);
 }
 
 template<typename Iterator, typename Functor>
-typename hydra::thrust::detail::enable_if<
-    detail::is_hydra_functor<Functor>::value ,
-    Range<hydra::thrust::reverse_iterator<Iterator>, Functor> >::type
+requires (detail::HydraFunctor<Functor>)
+Range<hydra::thrust::reverse_iterator<Iterator>, Functor>
 make_reverse_range(Iterator begin, Iterator end,Functor const& functor ){
 
 	typedef hydra::thrust::reverse_iterator<Iterator> reverse_iterator_type;
@@ -159,10 +161,8 @@ make_reverse_range(Iterator begin, Iterator end,Functor const& functor ){
 
 
 template<typename Iterable, typename Functor>
-typename hydra::thrust::detail::enable_if<
-	detail::is_iterable<Iterable>::value &&
-	detail::is_hydra_functor<Functor>::value,
- Range<decltype(std::declval<Iterable>().begin()), Functor> >::type
+requires (detail::Iterable<Iterable> && detail::HydraFunctor<Functor>)
+Range<decltype(std::declval<Iterable>().begin()), Functor>
 make_range(Iterable const& iterable,Functor const& functor ){
 
 	typedef decltype(hydra::begin(iterable)) iterator_type;
@@ -171,10 +171,8 @@ make_range(Iterable const& iterable,Functor const& functor ){
 }
 
 template<typename Iterable, typename Functor>
-typename hydra::thrust::detail::enable_if<
-	detail::is_iterable<Iterable>::value &&
-	detail::is_hydra_functor<Functor>::value,
- Range<decltype(std::declval<Iterable>().begin()), Functor> >::type
+requires (detail::Iterable<Iterable> && detail::HydraFunctor<Functor>)
+Range<decltype(std::declval<Iterable>().begin()), Functor>
 make_range(Iterable&& iterable,Functor const& functor ){
 
 	typedef decltype(hydra::begin(std::forward<Iterable>(iterable))) iterator_type;
@@ -185,10 +183,8 @@ make_range(Iterable&& iterable,Functor const& functor ){
 
 
 template<typename Iterable, typename Functor>
-typename hydra::thrust::detail::enable_if<
-    detail::is_reverse_iterable<Iterable>::value &&
-    detail::is_hydra_functor<Functor>::value ,
-    Range<decltype(std::declval<Iterable>().rbegin()), Functor> >::type
+requires (detail::ReverseIterable<Iterable> && detail::HydraFunctor<Functor>)
+Range<decltype(std::declval<Iterable>().rbegin()), Functor>
 make_reverse_range(Iterable const& iterable,Functor const& functor ){
 
 	typedef decltype(hydra::rbegin(iterable)) iterator_reverse_type;
@@ -198,10 +194,8 @@ make_reverse_range(Iterable const& iterable,Functor const& functor ){
 
 
 template<typename Iterable, typename Functor>
-typename hydra::thrust::detail::enable_if<
-    detail::is_reverse_iterable<Iterable>::value &&
-    detail::is_hydra_functor<Functor>::value ,
-    Range<decltype(std::declval<Iterable>().rbegin()), Functor> >::type
+requires (detail::ReverseIterable<Iterable> && detail::HydraFunctor<Functor>)
+Range<decltype(std::declval<Iterable>().rbegin()), Functor>
 make_reverse_range(Iterable&& iterable,Functor const& functor ){
 
 	typedef decltype(hydra::rbegin( std::forward<Iterable>(iterable) )) iterator_reverse_type;
@@ -211,11 +205,8 @@ make_reverse_range(Iterable&& iterable,Functor const& functor ){
 
 
 template<typename Iterable, typename Functor>
-typename hydra::thrust::detail::enable_if<
-    detail::is_iterable<Iterable>::value &&
-    ( detail::is_hydra_functor<Functor>::value ||
-      detail::is_hydra_lambda<Functor>::value ) ,
-    Range<decltype(std::declval< const Iterable>().begin()), Functor> >::type
+requires (detail::Iterable<Iterable> && detail::HydraCallable<Functor>)
+Range<decltype(std::declval< const Iterable>().begin()), Functor>
 operator|(Iterable const& iterable, Functor const& functor){
 
 	typedef decltype(hydra::begin(iterable)) iterator_type;
@@ -225,11 +216,8 @@ operator|(Iterable const& iterable, Functor const& functor){
 
 
 template<typename Iterable, typename Functor>
-typename hydra::thrust::detail::enable_if<
-    detail::is_iterable<Iterable>::value &&
-    (detail::is_hydra_functor<Functor>::value ||
-     detail::is_hydra_lambda<Functor>::value ),
-    Range<decltype(std::declval<Iterable>().begin()), Functor> >::type
+requires (detail::Iterable<Iterable> && detail::HydraCallable<Functor>)
+Range<decltype(std::declval<Iterable>().begin()), Functor>
 operator|(Iterable&& iterable, Functor const& functor){
 
 	typedef decltype(hydra::begin( std::forward<Iterable>(iterable) )) iterator_type;
@@ -239,11 +227,10 @@ operator|(Iterable&& iterable, Functor const& functor){
 }
 
 template<typename Iterable>
-typename hydra::thrust::detail::enable_if<
-    detail::is_iterable<Iterable>::value ,
-    Range<
+requires (detail::Iterable<Iterable>)
+Range<
      hydra::thrust::reverse_iterator<
-     	 decltype(std::declval<Iterable>().begin()) >>>::type
+     	 decltype(std::declval<Iterable>().begin()) >>
 reverse(Iterable&& iterable) {
 
 	typedef decltype(hydra::begin(iterable)) iterator_type;

--- a/hydra/detail/Reduce.inl
+++ b/hydra/detail/Reduce.inl
@@ -35,12 +35,13 @@
 #include <hydra/detail/external/hydra_thrust/reduce.h>
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
 #include <hydra/Range.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
 template<typename Iterable>
-typename std::enable_if<hydra::detail::is_iterable<Iterable>::value,
-typename hydra::thrust::iterator_traits<decltype(std::declval<Iterable>().begin())>::value_type >::type
+requires (detail::Iterable<Iterable>)
+typename hydra::thrust::iterator_traits<decltype(std::declval<Iterable>().begin())>::value_type
 reduce(Iterable&& iterable){
 
 	return hydra::thrust::reduce(std::forward<Iterable>(iterable).begin(),
@@ -50,7 +51,8 @@ reduce(Iterable&& iterable){
 template<typename Iterable, typename Functor,
  	 	 typename T = typename hydra::thrust::iterator_traits<
 		     decltype(std::declval<Iterable>().begin())>::value_type >
-typename std::enable_if<hydra::detail::is_iterable<Iterable>::value, T >::type
+requires (detail::Iterable<Iterable>)
+T
 reduce(Iterable&& iterable, T const& init, Functor const& binary_functor){
 
 

--- a/hydra/detail/Scatter.inl
+++ b/hydra/detail/Scatter.inl
@@ -35,14 +35,17 @@
 #include <utility>
 #include <hydra/detail/external/hydra_thrust/scatter.h>
 #include <hydra/Range.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
 template<typename Iterable_Source, typename Iterable_Target, typename Iterable_Map>
-typename std::enable_if<hydra::detail::is_iterable<Iterable_Source>::value
-					 && hydra::detail::is_iterable<Iterable_Target>::value
-					 && hydra::detail::is_iterable<Iterable_Map>::value,
-Range<decltype(std::declval<Iterable_Target&>().begin())>>::type
+requires (
+	detail::Iterable<Iterable_Source> &&
+	detail::Iterable<Iterable_Target> &&
+	detail::Iterable<Iterable_Map>
+)
+Range<decltype(std::declval<Iterable_Target&>().begin())>
 scatter(Iterable_Source&& source, Iterable_Map&& map, Iterable_Target&& target){
 
 	hydra::thrust::scatter(std::forward<Iterable_Source>(source).begin(),
@@ -56,9 +59,8 @@ scatter(Iterable_Source&& source, Iterable_Map&& map, Iterable_Target&& target){
 
 /*
 template<typename Iterable_Source, typename Iterable_Target, typename Iterator_Map>
-typename std::enable_if<hydra::detail::is_iterable<Iterable_Source>::value
-					 && hydra::detail::is_iterable<Iterable_Target>::value,
-Range<decltype(std::declval<Iterable_Target&>().begin())>>::type
+requires (hydra::detail::Iterable<Iterable_Source> && hydra::detail::Iterable<Iterable_Target>)
+Range<decltype(std::declval<Iterable_Target&>().begin())>
 scatter(Iterable_Source& source, Range<Iterator_Map>&& map, Iterable_Target& target){
 
 	hydra::thrust::scatter( source.begin(), source.end(),
@@ -68,8 +70,8 @@ scatter(Iterable_Source& source, Range<Iterator_Map>&& map, Iterable_Target& tar
 
 
 template<typename Iterator_Source, typename Iterable_Target, typename Iterator_Map>
-typename std::enable_if<hydra::detail::is_iterable<Iterable_Target>::value,
-Range<decltype(std::declval<Iterable_Target&>().begin())>>::type
+requires (hydra::detail::Iterable<Iterable_Target>)
+Range<decltype(std::declval<Iterable_Target&>().begin())>
 scatter(Range<Iterator_Source>&& source, Range<Iterator_Map>&& map, Iterable_Target& target){
 
 	hydra::thrust::scatter( source.begin(), source.end(),

--- a/hydra/detail/Sort.inl
+++ b/hydra/detail/Sort.inl
@@ -34,13 +34,14 @@
 #include <utility>
 #include <hydra/detail/external/hydra_thrust/sort.h>
 #include <hydra/Range.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 
 namespace hydra {
 
 template<typename Iterable, typename Iterator=decltype(std::declval<Iterable>().begin())>
-typename std::enable_if<hydra::detail::is_iterable<Iterable>::value,
-Range<decltype(std::declval<Iterable&>().begin())>>::type
+requires (detail::Iterable<Iterable>)
+Range<decltype(std::declval<Iterable&>().begin())>
 sort(Iterable& iterable){
 
 	hydra::thrust::sort(iterable.begin(), iterable.end() );
@@ -50,8 +51,8 @@ sort(Iterable& iterable){
 
 template<typename Iterable, typename Functor,
 typename Iterator=decltype(std::declval<Iterable>().begin())>
-typename std::enable_if<hydra::detail::is_iterable<Iterable>::value,
-Range<decltype(std::declval<Iterable&>().begin())>>::type
+requires (detail::Iterable<Iterable>)
+Range<decltype(std::declval<Iterable&>().begin())>
 sort(Iterable& iterable, Functor const& comparator){
 
 	hydra::thrust::sort(iterable.begin(), iterable.end(), comparator);
@@ -63,8 +64,8 @@ template<typename Iterable,typename Iterable_Key,
 typename Iterator=decltype(std::declval<Iterable>().begin()),
 typename Iterator_Key=decltype(std::declval<Iterable_Key>().begin()),
 typename Value_Key=decltype(*std::declval<Iterator_Key>().begin()) >
-typename std::enable_if<hydra::detail::is_iterable<Iterable>::value,
-Range<decltype(std::declval<Iterable&>().begin())>>::type
+requires (detail::Iterable<Iterable>)
+Range<decltype(std::declval<Iterable&>().begin())>
 sort_by_key(Iterable& iterable, Iterable_Key& keys){
 
 	using hydra::thrust::system::detail::generic::select_system;
@@ -84,8 +85,8 @@ sort_by_key(Iterable& iterable, Iterable_Key& keys){
 template<typename Iterable,typename Iterator_Key, typename Functor,
 typename Iterator=decltype(std::declval<Iterable>().begin()),
 typename Value_Key=decltype(*std::declval<Range<Iterator_Key,Functor>>().begin()) >
-typename std::enable_if<hydra::detail::is_iterable<Iterable>::value,
-Range<decltype(std::declval<Iterable&>().begin())>>::type
+requires (detail::Iterable<Iterable>)
+Range<decltype(std::declval<Iterable&>().begin())>
 sort_by_key(Iterable& iterable, Range<Iterator_Key,Functor> keys){
 
 	using hydra::thrust::system::detail::generic::select_system;

--- a/hydra/detail/SparseHistogram.inl
+++ b/hydra/detail/SparseHistogram.inl
@@ -42,6 +42,7 @@
 #include <hydra/detail/external/hydra_thrust/memory.h>
 
 #include<utility>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -508,7 +509,8 @@ SparseHistogram<T, 1,  detail::BackendPolicy<BACKEND>,detail::unidimensional >::
 
 template<typename T,  size_t N , hydra::detail::Backend BACKEND>
 template<size_t M>
-inline typename std::enable_if< M==2, T >::type
+requires (M==2)
+inline T
 SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>::Interpolate( std::array<size_t,2> const&  point){
 
 	return spline2D(this->GetBinsCenters(placeholders::_0).begin(), this->GetBinsCenters(placeholders::_0).end(),
@@ -518,7 +520,8 @@ SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional
 
 template<typename T,  size_t N , hydra::detail::Backend BACKEND>
 template<size_t M>
-inline typename std::enable_if< M==3, T >::type
+requires (M==3)
+inline T
 SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>::Interpolate( std::array<size_t,3> const&  point){
 
 	return spline3D(this->GetBinsCenters(placeholders::_0).begin(), this->GetBinsCenters(placeholders::_0).end(),
@@ -530,7 +533,8 @@ SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional
 
 template<typename T,  size_t N , hydra::detail::Backend BACKEND>
 template<size_t M>
-inline typename std::enable_if< M==4, T >::type
+requires (M==4)
+inline T
 SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>::Interpolate( std::array<size_t,4> const&  point){
 
 	return spline4D(
@@ -570,8 +574,8 @@ make_sparse_histogram( detail::BackendPolicy<BACKEND>, std::array<size_t, N> gri
 
 //iterable based
 template< typename T, size_t N , hydra::detail::Backend BACKEND, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t, N> grid,
 		std::array<double, N>lowerlimits,   std::array<double, N> upperlimits,	Iterable&& data){
 
@@ -581,9 +585,8 @@ make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t
 }
 
 template< typename T, size_t N , hydra::detail::Backend BACKEND, typename Iterable1,typename Iterable2 >
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value&&
-hydra::detail::is_iterable<Iterable2>::value,
-SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>>::type
+requires (hydra::detail::Iterable<Iterable1>&& hydra::detail::Iterable<Iterable2>)
+inline SparseHistogram< T, N,  detail::BackendPolicy<BACKEND>, detail::multidimensional>
 make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, std::array<size_t, N> grid,
 		std::array<double, N>lowerlimits,   std::array<double, N> upperlimits,
 		Iterable1&& data,
@@ -626,8 +629,8 @@ make_sparse_histogram( detail::BackendPolicy<BACKEND>, size_t grid, double lower
 
 //iterable based
 template< typename T, hydra::detail::Backend BACKEND, typename Iterable>
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable>::value,
-SparseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>>::type
+requires (hydra::detail::Iterable<Iterable>)
+inline SparseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>
 make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, size_t grid,
 		double lowerlimits,  double upperlimits,	Iterable&& data){
 
@@ -637,9 +640,8 @@ make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, size_t grid,
 }
 
 template< typename T, hydra::detail::Backend BACKEND, typename Iterable1,typename Iterable2 >
-inline typename std::enable_if< hydra::detail::is_iterable<Iterable1>::value&&
-hydra::detail::is_iterable<Iterable2>::value,
-SparseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>>::type
+requires (hydra::detail::Iterable<Iterable1>&& hydra::detail::Iterable<Iterable2>)
+inline SparseHistogram< T, 1,  detail::BackendPolicy<BACKEND>, detail::unidimensional>
 make_sparse_histogram( detail::BackendPolicy<BACKEND> backend, size_t grid,
 		double lowerlimits, double upperlimits,
 		Iterable1&& data,

--- a/hydra/detail/Spline.inl
+++ b/hydra/detail/Spline.inl
@@ -47,6 +47,8 @@
 #include <math.h>
 #include <algorithm>
 #include <type_traits>
+#include <concepts>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -78,7 +80,8 @@ inline Iterator lower_bound(Iterator first, Iterator last, const T& value)
 }
 
 template<typename T=double>
-inline typename std::enable_if< std::is_convertible<T, double>::value, T>::type
+requires (std::is_convertible_v<T, double>)
+inline T
 __hydra_host__ __hydra_device__
 cubic_spline(size_t i, size_t N,  T const (&X)[4] ,   T const (&Y)[4], T value ){
 
@@ -134,11 +137,12 @@ cubic_spline(size_t i, size_t N,  T const (&X)[4] ,   T const (&Y)[4], T value )
 
 
 template<typename Iterator1, typename Iterator2,typename Type>
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-                      std::is_convertible<typename hydra::thrust::iterator_traits<Iterator1>::value_type, double >::value &&
-                      std::is_convertible<typename hydra::thrust::iterator_traits<Iterator2>::value_type, double >::value &&
-					  std::is_convertible<Type, double >::value, Type>::type
+requires (
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<Iterator1>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<Iterator2>::value_type, double > &&
+	std::is_convertible_v<Type, double >
+)
+__hydra_host__ __hydra_device__ inline Type
 spline(Iterator1 first, Iterator1 last,  Iterator2 measurements, Type value) {
 
 		using hydra::thrust::min;
@@ -156,14 +160,14 @@ spline(Iterator1 first, Iterator1 last,  Iterator2 measurements, Type value) {
 	}
 
 template<typename Iterable1, typename Iterable2,typename Type>
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-                       hydra::detail::is_iterable<Iterable1>::value &&
-                       hydra::detail::is_iterable<Iterable2>::value &&
-                       std::is_convertible<typename Iterable1::value_type , double >::value &&
-                       std::is_convertible<typename Iterable2::value_type , double >::value &&
-					   std::is_convertible<Type, double >::value ,
-                       Type >::type
+requires (
+	detail::Iterable<Iterable1> &&
+	detail::Iterable<Iterable2> &&
+	std::is_convertible_v<typename Iterable1::value_type , double > &&
+	std::is_convertible_v<typename Iterable2::value_type , double > &&
+	std::is_convertible_v<Type, double >
+)
+__hydra_host__ __hydra_device__ inline Type
 spline(Iterable1&& abscissae,  Iterable2&& ordinate, Type value){
 
 	return spline( std::forward<Iterable1>(abscissae).begin(),

--- a/hydra/detail/Spline2D.inl
+++ b/hydra/detail/Spline2D.inl
@@ -30,13 +30,14 @@
 #ifndef SPILINE2D_INL_
 #define SPILINE2D_INL_
 
-
+#include <concepts>
 
 #include <hydra/detail/Config.h>
 #include <hydra/detail/BackendPolicy.h>
 #include <hydra/Types.h>
 #include <hydra/Function.h>
 #include <hydra/detail/utility/CheckValue.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 
 namespace hydra {
@@ -54,13 +55,14 @@ namespace hydra {
  * @return
  */
 template<typename IteratorX, typename IteratorY, typename IteratorM, typename TypeX, typename TypeY >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double >::value &&
-	std::is_convertible<TypeX, double >::value &&
-	std::is_convertible<TypeY, double >::value, double>::type
+requires (
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline2D(IteratorX firstx, IteratorX lastx, IteratorY firsty, IteratorY lasty, IteratorM measurements, TypeX x, TypeY y)
 {
 	//get the neighbors on x and y-direction first
@@ -112,17 +114,17 @@ spline2D(IteratorX firstx, IteratorX lastx, IteratorY firsty, IteratorY lasty, I
 }
 
 template<typename IterableX, typename IterableY,typename IterableM, typename TypeX,typename TypeY >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-					   hydra::detail::is_iterable<IterableX>::value &&
-                       hydra::detail::is_iterable<IterableY>::value &&
-                       hydra::detail::is_iterable<IterableM>::value &&
-                       std::is_convertible<typename IterableX::value_type, double >::value &&
-                       std::is_convertible<typename IterableY::value_type, double >::value &&
-					   std::is_convertible<typename IterableM::value_type, double >::value &&
-					   std::is_convertible<TypeX, double >::value &&
-					   std::is_convertible<TypeY, double >::value ,
-                       double >::type
+requires (
+	detail::Iterable<IterableX> &&
+	detail::Iterable<IterableY> &&
+	detail::Iterable<IterableM> &&
+	std::is_convertible_v<typename IterableX::value_type, double > &&
+	std::is_convertible_v<typename IterableY::value_type, double > &&
+	std::is_convertible_v<typename IterableM::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline2D(IterableX&& abscissa_x,  IterableY&& abscissa_y, IterableM measurements, TypeX x, TypeX y){
 
 

--- a/hydra/detail/Spline3D.inl
+++ b/hydra/detail/Spline3D.inl
@@ -30,28 +30,30 @@
 #ifndef SPILINE3D_INL_
 #define SPILINE3D_INL_
 
-
+#include <concepts>
 
 #include <hydra/detail/Config.h>
 #include <hydra/detail/BackendPolicy.h>
 #include <hydra/Types.h>
 #include <hydra/Function.h>
 #include <hydra/detail/utility/CheckValue.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 
 namespace hydra {
 
 
 template<typename IteratorX, typename IteratorY, typename IteratorZ, typename IteratorM, typename TypeX, typename TypeY, typename TypeZ >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorZ>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double >::value &&
-	std::is_convertible<TypeX, double >::value &&
-	std::is_convertible<TypeY, double >::value &&
-	std::is_convertible<TypeZ, double >::value, double>::type
+requires (
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorZ>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double > &&
+	std::is_convertible_v<TypeZ, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline3D(IteratorX firstx, IteratorX lastx,
 		 IteratorY firsty, IteratorY lasty,
 		 IteratorZ firstz, IteratorZ lastz,
@@ -124,20 +126,20 @@ spline3D(IteratorX firstx, IteratorX lastx,
 }
 
 template<typename IterableX, typename IterableY,typename IterableZ,typename IterableM, typename TypeX,typename TypeY, typename TypeZ >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-					   hydra::detail::is_iterable<IterableX>::value &&
-                       hydra::detail::is_iterable<IterableY>::value &&
-					   hydra::detail::is_iterable<IterableZ>::value &&
-                       hydra::detail::is_iterable<IterableM>::value &&
-                       std::is_convertible<typename IterableX::value_type, double >::value &&
-                       std::is_convertible<typename IterableY::value_type, double >::value &&
-					   std::is_convertible<typename IterableZ::value_type, double >::value &&
-					   std::is_convertible<typename IterableM::value_type, double >::value &&
-					   std::is_convertible<TypeX, double >::value &&
-					   std::is_convertible<TypeY, double >::value &&
-					   std::is_convertible<TypeZ, double >::value ,
-                       double >::type
+requires (
+	detail::Iterable<IterableX> &&
+	detail::Iterable<IterableY> &&
+	detail::Iterable<IterableZ> &&
+	detail::Iterable<IterableM> &&
+	std::is_convertible_v<typename IterableX::value_type, double > &&
+	std::is_convertible_v<typename IterableY::value_type, double > &&
+	std::is_convertible_v<typename IterableZ::value_type, double > &&
+	std::is_convertible_v<typename IterableM::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double > &&
+	std::is_convertible_v<TypeZ, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline3D(IterableX&& abscissa_x,  IterableY&& abscissa_y, IterableZ&& abscissa_z, IterableM measurements, TypeX x, TypeX y, TypeZ z ){
 
 

--- a/hydra/detail/Spline4D.inl
+++ b/hydra/detail/Spline4D.inl
@@ -30,13 +30,14 @@
 #ifndef SPILINE4D_INL_
 #define SPILINE4D_INL_
 
-
+#include <concepts>
 
 #include <hydra/detail/Config.h>
 #include <hydra/detail/BackendPolicy.h>
 #include <hydra/Types.h>
 #include <hydra/Function.h>
 #include <hydra/detail/utility/CheckValue.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 
 namespace hydra {
@@ -44,17 +45,18 @@ namespace hydra {
 
 template<typename IteratorX, typename IteratorY, typename IteratorW, typename IteratorZ, typename IteratorM,
           typename TypeX, typename TypeY, typename TypeW, typename TypeZ >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorW>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorZ>::value_type, double >::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double >::value &&
-	std::is_convertible<TypeX, double >::value &&
-	std::is_convertible<TypeY, double >::value &&
-	std::is_convertible<TypeW, double >::value &&
-	std::is_convertible<TypeZ, double >::value, double>::type
+requires (
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorX>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorY>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorW>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorZ>::value_type, double > &&
+	std::is_convertible_v<typename hydra::thrust::iterator_traits<IteratorM>::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double > &&
+	std::is_convertible_v<TypeW, double > &&
+	std::is_convertible_v<TypeZ, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline4D(IteratorX firstx, IteratorX lastx,
 		 IteratorY firsty, IteratorY lasty,
 		 IteratorW firstw, IteratorW lastw,
@@ -142,23 +144,23 @@ spline4D(IteratorX firstx, IteratorX lastx,
 }
 
 template<typename IterableX, typename IterableY,typename IterableW,typename IterableZ,typename IterableM, typename TypeX,typename TypeY, typename TypeW, typename TypeZ >
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-					   hydra::detail::is_iterable<IterableX>::value &&
-                       hydra::detail::is_iterable<IterableY>::value &&
-					   hydra::detail::is_iterable<IterableW>::value &&
-					   hydra::detail::is_iterable<IterableZ>::value &&
-                       hydra::detail::is_iterable<IterableM>::value &&
-                       std::is_convertible<typename IterableX::value_type, double >::value &&
-                       std::is_convertible<typename IterableY::value_type, double >::value &&
-					   std::is_convertible<typename IterableW::value_type, double >::value &&
-					   std::is_convertible<typename IterableZ::value_type, double >::value &&
-					   std::is_convertible<typename IterableM::value_type, double >::value &&
-					   std::is_convertible<TypeX, double >::value &&
-					   std::is_convertible<TypeY, double >::value &&
-					   std::is_convertible<TypeW, double >::value &&
-					   std::is_convertible<TypeZ, double >::value ,
-                       double >::type
+requires (
+	detail::Iterable<IterableX> &&
+	detail::Iterable<IterableY> &&
+	detail::Iterable<IterableW> &&
+	detail::Iterable<IterableZ> &&
+	detail::Iterable<IterableM> &&
+	std::is_convertible_v<typename IterableX::value_type, double > &&
+	std::is_convertible_v<typename IterableY::value_type, double > &&
+	std::is_convertible_v<typename IterableW::value_type, double > &&
+	std::is_convertible_v<typename IterableZ::value_type, double > &&
+	std::is_convertible_v<typename IterableM::value_type, double > &&
+	std::is_convertible_v<TypeX, double > &&
+	std::is_convertible_v<TypeY, double > &&
+	std::is_convertible_v<TypeW, double > &&
+	std::is_convertible_v<TypeZ, double >
+)
+__hydra_host__ __hydra_device__ inline double
 spline3D(IterableX&& abscissa_x,  IterableY&& abscissa_y, IterableW&& abscissa_w, IterableZ&& abscissa_z, IterableM measurements, TypeX x, TypeX y, TypeW w, TypeZ z ){
 
 

--- a/hydra/detail/Sum.h
+++ b/hydra/detail/Sum.h
@@ -41,6 +41,7 @@
 #include <hydra/Types.h>
 #include <hydra/Function.h>
 #include <hydra/detail/FunctorTraits.h>
+#include <hydra/detail/FunctorConcepts.h>
 #include <hydra/detail/utility/Utility_Tuple.h>
 #include <hydra/detail/base_functor.h>
 #include <hydra/detail/Constant.h>
@@ -137,10 +138,8 @@ public:
  * operator+ for two functors.
  */
 template<typename T1, typename T2>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T1>::value || detail::is_hydra_lambda<T1>::value ) &&
-(detail::is_hydra_functor<T2>::value || detail::is_hydra_lambda<T2>::value ),
-Sum<T1, T2> >::type
+requires (detail::HydraCallable<T1> && detail::HydraCallable<T2>)
+inline Sum<T1, T2>
 operator+(T1 const& F1, T2 const& F2)
 {
 	return  Sum<T1,T2>(F1, F2);
@@ -150,10 +149,8 @@ operator+(T1 const& F1, T2 const& F2)
  * operator+ for a value and a functor.
  */
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Sum< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && std::is_arithmetic_v<U>)
+inline Sum< Constant<U>, T>
 operator+(U const cte, T const& F)
 {
 	return  Constant<U>(cte)+F;
@@ -163,10 +160,8 @@ operator+(U const cte, T const& F)
  * operator+ for a value and a functor.
  */
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value  ) &&
-(std::is_arithmetic<U>::value),
-Sum< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && std::is_arithmetic_v<U>)
+inline Sum< Constant<U>, T>
 operator+( T const& F, U cte)
 {
 	return  Constant<U>(cte)+F;
@@ -176,10 +171,8 @@ operator+( T const& F, U cte)
  * operator+ for a complex value and a functor.
  */
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Sum< Constant<hydra::complex<U>>, T> >::type
+requires (detail::HydraCallable<T> && std::is_arithmetic_v<U>)
+inline Sum< Constant<hydra::complex<U>>, T>
 operator+(hydra::complex<U> const& cte, T const& F)
 {
 	return  Constant<hydra::complex<U> >(cte)+F;
@@ -189,10 +182,8 @@ operator+(hydra::complex<U> const& cte, T const& F)
  * operator+ for a complex value and a functor.
  */
 template <typename T, typename U>
-inline typename std::enable_if<
-(detail::is_hydra_functor<T>::value || detail::is_hydra_lambda<T>::value ) &&
-(std::is_arithmetic<U>::value),
-Sum< Constant<U>, T> >::type
+requires (detail::HydraCallable<T> && std::is_arithmetic_v<U>)
+inline Sum< Constant<U>, T>
 operator+( T const& F, hydra::complex<U> const& cte)
 {
 	return  Constant<hydra::complex<U> >(cte)+F;
@@ -201,12 +192,9 @@ operator+( T const& F, hydra::complex<U> const& cte)
 
 // Convenience function
 template <typename F1, typename F2, typename ...Fs>
-inline typename std::enable_if<
-(detail::is_hydra_functor<F1>::value || detail::is_hydra_lambda<F1>::value ) &&
-(detail::is_hydra_functor<F2>::value || detail::is_hydra_lambda<F2>::value ) &&
-detail::all_true<
-(detail::is_hydra_functor<Fs>::value || detail::is_hydra_lambda<Fs>::value )...>::value,
-Sum<F1, F2,Fs...>>::type
+requires (detail::HydraCallable<F1> && detail::HydraCallable<F2> &&
+          (detail::HydraCallable<Fs> && ...))
+inline Sum<F1, F2,Fs...>
 sum(F1 const& f1, F2 const& f2, Fs const&... functors )
 {
 	return  Sum<F1, F2,Fs... >(f1,f2, functors ... );

--- a/hydra/detail/Transform.inl
+++ b/hydra/detail/Transform.inl
@@ -36,14 +36,15 @@
 #include <hydra/detail/external/hydra_thrust/transform.h>
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
 #include <hydra/Range.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 
 namespace hydra {
 
 template<typename Iterable_Input, typename Iterable_Output, typename Functor,
 typename Iterator=decltype(std::declval<Iterable_Output>().begin())>
-typename std::enable_if<hydra::detail::is_iterable<Iterable_Output>::value,
-Range<decltype(std::declval<Iterable_Output&>().begin())>>::type
+requires (hydra::detail::Iterable<Iterable_Output>)
+Range<decltype(std::declval<Iterable_Output&>().begin())>
 transform(Iterable_Input&& iterable_input, Iterable_Output&& iterable_output,  Functor const& unary_functor){
 
 	hydra::thrust::transform(std::forward<Iterable_Input>(iterable_input).begin(),

--- a/hydra/detail/TupleConcepts.h
+++ b/hydra/detail/TupleConcepts.h
@@ -1,0 +1,76 @@
+/*----------------------------------------------------------------------------
+ *
+ *   Copyright (C) 2016 - 2023 Antonio Augusto Alves Junior
+ *
+ *   This file is part of Hydra Data Analysis Framework.
+ *
+ *   Hydra is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   Hydra is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with Hydra.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *---------------------------------------------------------------------------*/
+
+/*
+ * TupleConcepts.h
+ *
+ *  Created on: 28/06/2026
+ *      Author: Davide Brundu
+ */
+
+#ifndef TUPLECONCEPTS_H_
+#define TUPLECONCEPTS_H_
+
+#include <concepts>
+#include <type_traits>
+
+#include <hydra/detail/ArgumentTraits.h>
+
+namespace hydra {
+
+namespace detail {
+
+/**
+ * @brief Satisfied when @c T (after decay) is a Hydra/Thrust tuple type
+ * (see hydra::detail::is_tuple_type).
+ */
+template <typename T>
+concept TupleType = is_tuple_type<std::decay_t<T>>::value;
+
+/**
+ * @brief Satisfied when @c T (after decay) is a tuple whose elements are all
+ * Hydra function arguments (see hydra::detail::is_tuple_of_function_arguments).
+ */
+template <typename T>
+concept TupleOfFunctionArguments = is_tuple_of_function_arguments<std::decay_t<T>>::value;
+
+/**
+ * @brief Satisfied when @c T (after decay) is a Hydra function argument, i.e. a
+ * type derived from hydra::detail::FunctionArgument (see
+ * hydra::detail::is_function_argument). Named with the @c Arg suffix to avoid
+ * clashing with the @c FunctionArgument class template.
+ */
+template <typename T>
+concept FunctionArgumentArg = is_function_argument<std::decay_t<T>>::value;
+
+/**
+ * @brief Satisfied when the pack @c T... is a valid set of call arguments for a
+ * functor whose signature tuple is @c Signature
+ * (see hydra::detail::is_valid_type_pack).
+ */
+template <typename Signature, typename... T>
+concept ValidTypePack = is_valid_type_pack<Signature, T...>::value;
+
+}  // namespace detail
+
+}  // namespace hydra
+
+#endif /* TUPLECONCEPTS_H_ */

--- a/hydra/detail/TupleUtility.h
+++ b/hydra/detail/TupleUtility.h
@@ -55,13 +55,13 @@ namespace tuple_utility {
 }  // namespace tuple_utility
 
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	typename std::enable_if< detail::is_tuple<T>::value, T>::type
+	requires (detail::is_tuple<T>::value)
+	__hydra_host__ __hydra_device__ T
 	tupler( T const& data ) { return data;}
 
 	template<typename T>
-	__hydra_host__ __hydra_device__
-	typename std::enable_if<!detail::is_tuple<T>::value, hydra::tuple<T> >::type
+	requires (!detail::is_tuple<T>::value)
+	__hydra_host__ __hydra_device__ hydra::tuple<T>
 	tupler( T const& data )	{ return hydra::make_tuple( data ); }
 
 }  // namespace detail

--- a/hydra/detail/ZipIteratorUtility.h
+++ b/hydra/detail/ZipIteratorUtility.h
@@ -155,14 +155,16 @@ template<typename ...T>
 struct flat_tuple: merged_tuple< typename do_tuple<T>::type... > {};
 
 template<typename T>
-typename std::enable_if<is_tuple<T>::value, T>::type
+requires (is_tuple<T>::value)
+T
 tupler( T const& data )
 {
     return data;
 }
 
 template<typename T>
-typename std::enable_if< !is_tuple<T>::value , std::tuple<T> >::type
+requires (!is_tuple<T>::value)
+std::tuple<T>
 tupler( T const& data )
 {
     return std::make_tuple( data );
@@ -205,8 +207,8 @@ namespace detail {
 
 
 template<typename ...T>
-typename std::enable_if< all_true<is_zip_iterator<T>::value...>::value,
-                 typename detail::merged_zip_iterator<T...>::type >::type
+requires (all_true<is_zip_iterator<T>::value...>::value)
+typename detail::merged_zip_iterator<T...>::type
 zip_iterator_cat( T const&... zip_iterators)
 {
 	return hydra::thrust::make_zip_iterator(
@@ -216,19 +218,17 @@ zip_iterator_cat( T const&... zip_iterators)
 namespace meld_iterators_ns {
 
 template<typename T>
+requires (detail::is_iterator<T>::value && detail::is_zip_iterator<T>::value)
 auto convert_to_tuple(T&& iterator)
--> typename std::enable_if< detail::is_iterator<T>::value &&
-                            detail::is_zip_iterator<T>::value,
-    decltype( std::declval<T>().get_iterator_tuple() ) >::type
+-> decltype( std::declval<T>().get_iterator_tuple() )
 {
 	return std::forward<T>(iterator).get_iterator_tuple();
 }
 
 template<typename T>
+requires (detail::is_iterator<T>::value && (!detail::is_zip_iterator<T>::value))
 auto convert_to_tuple(T&& iterator)
--> typename std::enable_if< detail::is_iterator<T>::value &&
-                          (!detail::is_zip_iterator<T>::value),
-hydra::thrust::tuple<T> >::type
+-> hydra::thrust::tuple<T>
 {
 	return hydra::thrust::make_tuple(std::forward<T>(iterator));
 }

--- a/hydra/detail/cufft/BaseCuFFT.h
+++ b/hydra/detail/cufft/BaseCuFFT.h
@@ -50,6 +50,7 @@
 
 //Hydra wrappers
 #include<hydra/detail/cufft/WrappersCuFFT.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -120,8 +121,8 @@ public:
 
 	template<typename Iterable,
 	typename Type =	typename decltype(*std::declval<Iterable&>().begin())::value_type>
-	inline typename std::enable_if<std::is_convertible<InputType, Type>::value
-	                        && detail::is_iterable<Iterable>::value, void>::type
+	requires (std::is_convertible_v<InputType, Type> && hydra::detail::Iterable<Iterable>)
+	inline void
 	LoadInputData( Iterable&& container)
 	{
 

--- a/hydra/detail/fftw/BaseFFTW.h
+++ b/hydra/detail/fftw/BaseFFTW.h
@@ -49,6 +49,7 @@
 
 //Hydra wrappers
 #include<hydra/detail/fftw/WrappersFFTW.h>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -120,8 +121,8 @@ public:
 
 	template<typename Iterable,
 	typename Type =	typename decltype(*std::declval<Iterable&>().begin())::value_type>
-	inline typename std::enable_if<std::is_convertible<InputType, Type>::value
-	                        && detail::is_iterable<Iterable>::value, void>::type
+	requires (std::is_convertible_v<InputType, Type> && hydra::detail::Iterable<Iterable>)
+	inline void
 	LoadInputData( Iterable&& container)
 	{
 

--- a/hydra/detail/functors/GetBinCenter.h
+++ b/hydra/detail/functors/GetBinCenter.h
@@ -90,12 +90,14 @@ struct GetBinCenter: public hydra::thrust::unary_function<size_t, typename tuple
 	// multiply static array elements
 	//----------------------------------------
 	template< size_t I>
-	__hydra_host__ __hydra_device__ inline typename std::enable_if< (I==N), void  >::type
+	requires ((I==N))
+	__hydra_host__ __hydra_device__ inline void
 	multiply( size_t (&)[N] , size_t&  )
 	{ }
 
 	template<size_t I=0>
-	__hydra_host__ __hydra_device__ inline typename std::enable_if< (I<N), void  >::type
+	requires ((I<N))
+	__hydra_host__ __hydra_device__ inline void
 	multiply( size_t (&obj)[N], size_t& result )
 	{
 		result = I==0? 1.0: result;
@@ -105,15 +107,15 @@ struct GetBinCenter: public hydra::thrust::unary_function<size_t, typename tuple
 
 	//end of recursion
 	template<size_t I>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (I==N), void  >::type
+	requires ((I==N))
+	__hydra_host__ __hydra_device__ inline void
 	get_indexes(size_t,  size_t (&)[N])
 	{}
 
 	//begin of the recursion
 	template<size_t I=0>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (I<N), void  >::type
+	requires ((I<N))
+	__hydra_host__ __hydra_device__ inline void
 	get_indexes(size_t index,  size_t (&indexes)[N] )
 	{
 		size_t factor    =  1;
@@ -259,14 +261,14 @@ struct GetAxisBinCenter: public hydra::thrust::unary_function<size_t, T>
 	// multiply static array elements
 	//----------------------------------------
 	template< size_t J>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (J==N), void  >::type
+	requires ((J==N))
+	__hydra_host__ __hydra_device__ inline void
 	multiply( size_t (&)[N] , size_t&  )
 	{ }
 
 	template<size_t J=0>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (J<N), void  >::type
+	requires ((J<N))
+	__hydra_host__ __hydra_device__ inline void
 	multiply( size_t (&obj)[N], size_t& result )
 	{
 		result = J==0? 1.0: result;
@@ -276,15 +278,15 @@ struct GetAxisBinCenter: public hydra::thrust::unary_function<size_t, T>
 
 	//end of recursion
 	template<size_t J>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (J==N), void  >::type
+	requires ((J==N))
+	__hydra_host__ __hydra_device__ inline void
 	get_indexes(size_t,  size_t (&)[N])
 	{}
 
 	//begin of the recursion
 	template<size_t J=0>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (J<N), void  >::type
+	requires ((J<N))
+	__hydra_host__ __hydra_device__ inline void
 	get_indexes(size_t index,  size_t (&indexes)[N] )
 	{
 		size_t factor    =  1;

--- a/hydra/detail/functors/GetGlobalBin.h
+++ b/hydra/detail/functors/GetGlobalBin.h
@@ -84,13 +84,13 @@ struct GetGlobalBin: public hydra::thrust::unary_function<typename tuple_type<N,
 	//k = i_1*(dim_2*...*dim_n) + i_2*(dim_3*...*dim_n) + ... + i_{n-1}*dim_n + i_n
 
 	template<size_t I>
-	__hydra_host__ __hydra_device__
-	typename hydra::thrust::detail::enable_if< I== N, void>::type
+	requires (I== N)
+	__hydra_host__ __hydra_device__ void
 	get_global_bin(const size_t (&)[N], size_t& )const{ }
 
 	template<size_t I=0>
-	__hydra_host__ __hydra_device__
-	typename hydra::thrust::detail::enable_if< (I< N), void>::type
+	requires ((I< N))
+	__hydra_host__ __hydra_device__ void
 	get_global_bin(const size_t (&indexes)[N], size_t& index) const
 	{
 	    size_t prod =1;
@@ -190,8 +190,8 @@ struct GetGlobalBin<1,T>: public hydra::thrust::unary_function<T,size_t>
 	}
 
 	template<typename ConvertibleType>
-	__hydra_host__ __hydra_device__
-	typename std::enable_if< std::is_convertible_v<ConvertibleType, T>, size_t>::type
+	requires (std::is_convertible_v<ConvertibleType, T>)
+	__hydra_host__ __hydra_device__ size_t
     operator()(ConvertibleType const& value) const {
 
 		T X = value;

--- a/hydra/detail/functors/LogLikelihood.h
+++ b/hydra/detail/functors/LogLikelihood.h
@@ -91,9 +91,9 @@ struct LogLikelihood
 	~LogLikelihood(){}
 
     template<typename U = cache_value_type >
+	requires (!std::is_same<U, null_type>::value)
 	__hydra_host__ __hydra_device__ inline
-	GReal_t operator()(size_t index, const typename std::enable_if< !std::is_same<U,
-	       	null_type>::value, void >::type* dummy=0 ){
+	GReal_t operator()(size_t index){
 
     	          auto      C = (cache_value_type) fCacheBegin[index];
     	          auto      X = ((point_type) fDataBegin[index]).GetCoordinates() ;
@@ -104,9 +104,9 @@ struct LogLikelihood
 	}
 
     template<typename U = cache_value_type >
+   	requires (std::is_same<U, null_type>::value)
    	__hydra_host__ __hydra_device__ inline
-   	GReal_t operator()(size_t index, const typename std::enable_if< std::is_same<U,
-   	       	null_type>::value, void >::type* dummy=0 ){
+   	GReal_t operator()(size_t index){
 
 
         auto X = ((point_type) fDataBegin[index]).GetCoordinates() ;

--- a/hydra/detail/functors/ProcessGenzMalikQuadrature.h
+++ b/hydra/detail/functors/ProcessGenzMalikQuadrature.h
@@ -178,13 +178,13 @@ private:
 	\f$ \int_a^b f(x)\,dx \approx \frac{b-a}{2} \sum_{i=1}^n w_i f\left(\frac{b-a}{2}x_i + \frac{a+b}{2}\right) \f$.
 	*/
 	template<typename Abscissa, typename TransAbscissa , size_t I>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (I== hydra::thrust::tuple_size<TransAbscissa>::value), void  >::type
+	requires ((I== hydra::thrust::tuple_size<TransAbscissa>::value))
+	__hydra_host__ __hydra_device__ inline void
 	get_transformed_abscissa_helper( Abscissa const& ,  TransAbscissa& ){}
 
 	template<typename Abscissa, typename TransAbscissa , size_t I=0>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (I < hydra::thrust::tuple_size<TransAbscissa>::value), void  >::type
+	requires ((I < hydra::thrust::tuple_size<TransAbscissa>::value))
+	__hydra_host__ __hydra_device__ inline void
 	get_transformed_abscissa_helper(  Abscissa const& abscissa, TransAbscissa& transformed_abscissa  ){
 
 		hydra::thrust::get<I>(transformed_abscissa)  =
@@ -210,13 +210,13 @@ private:
 
 //-----------------------
 	template<typename T, int I>
-	__hydra_host__ __hydra_device__
-	typename std::enable_if< (I==N),void >::type
+	requires ((I==N))
+	__hydra_host__ __hydra_device__ void
 	get_dim_helper( T const&, int& ,  int& ){ }
 
 	template<typename T, int I=0>
-	__hydra_host__ __hydra_device__
-	typename std::enable_if< (I< N),void >::type
+	requires ((I< N))
+	__hydra_host__ __hydra_device__ void
 	get_dim_helper( T const& X, int& result,  int& found_zeros ){
 
 		result +=  hydra::thrust::get<I+3>(X)>0.0 || hydra::thrust::get<I+3>(X) < 0.0 ?I:0.0;

--- a/hydra/detail/functors/ProcessSPlot.h
+++ b/hydra/detail/functors/ProcessSPlot.h
@@ -94,13 +94,13 @@ struct CovMatrixUnary
 
 
 	template<typename T, int N, int I>
-	__hydra_host__ __hydra_device__
-	inline typename hydra::thrust::detail::enable_if<(I == N*N),void >::type
+	requires ((I == N*N))
+	__hydra_host__ __hydra_device__ inline void
 	set_matrix(double denominator, T&&, hydra::Eigen::Matrix<double, N, N>&){ }
 
 	template<typename T, int N, int I=0>
-	__hydra_host__ __hydra_device__
-	inline typename hydra::thrust::detail::enable_if<(I < N*N),void >::type
+	requires ((I < N*N))
+	__hydra_host__ __hydra_device__ inline void
 	set_matrix(double denominator, T&& ftuple, hydra::Eigen::Matrix<double, N, N>& fcovmatrix  )
 	{
 		fcovmatrix(index<N, I>::I, index<N, I>::J ) = \
@@ -211,8 +211,8 @@ struct SWeights
 
 
 	template<typename Type, int V=W >
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (V < 0), tuple_t >::type
+	requires ((V < 0))
+	__hydra_host__ __hydra_device__ inline tuple_t
 	//inline tuple_t
 	operator()(Type x)
 	{
@@ -231,8 +231,8 @@ struct SWeights
 	}
 
 	template<typename Type, int V=W>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (V >= 0), double >::type
+	requires ((V >= 0))
+	__hydra_host__ __hydra_device__ inline double
 	//inline tuple_t
 	operator()(Type x)
 	{

--- a/hydra/detail/utility/Generic.h
+++ b/hydra/detail/utility/Generic.h
@@ -33,6 +33,7 @@
 //std
 #include <type_traits>
 #include <array>
+#include <concepts>
 
 
 namespace hydra {
@@ -188,12 +189,14 @@ template<class ...A> struct CanConvert{
 	// multiply  std::array elements
 	//----------------------------------------
 	template<typename T, size_t N, size_t I>
-	typename std::enable_if< (I==N), void  >::type
+	requires ((I==N))
+	void
 	multiply( std::array<T, N> const& , T&  )
 	{ }
 
 	template<typename T, size_t N, size_t I=0>
-	typename std::enable_if< (I<N), void  >::type
+	requires ((I<N))
+	void
 	multiply( std::array<T, N> const&  obj, T& result )
 	{
 		result = I==0? 1.0: result;
@@ -205,12 +208,14 @@ template<class ...A> struct CanConvert{
 	// multiply static array elements
 	//----------------------------------------
 	template<typename T, size_t N, size_t I>
-	typename std::enable_if< (I==N), void  >::type
+	requires ((I==N))
+	void
 	multiply(const T (&)[N] , T& )
 	{ }
 
 	template<typename T, size_t N, size_t I=0>
-	typename std::enable_if< (I<N), void  >::type
+	requires ((I<N))
+	void
 	multiply(const  T (&obj)[N], T& result )
 	{
 		result = I==0? 1.0: result;
@@ -225,13 +230,15 @@ template<class ...A> struct CanConvert{
 	//-------------------------
 	//end of recursion
 	template<typename T, size_t DIM, size_t I>
-	typename std::enable_if< (I==DIM) && (std::is_integral<T>::value), void  >::type
+	requires ((I==DIM) && (std::integral<T>))
+	void
 	get_indexes(size_t , std::array<T, DIM> const& , std::array<T,DIM>& )
 	{}
 
 	//begin of the recursion
 	template<typename T, size_t DIM, size_t I=0>
-	typename std::enable_if< (I<DIM) && (std::is_integral<T>::value), void  >::type
+	requires ((I<DIM) && (std::integral<T>))
+	void
 	get_indexes(size_t index, std::array<T, DIM> const& depths, std::array<T,DIM>& indexes)
 	{
 
@@ -251,13 +258,15 @@ template<class ...A> struct CanConvert{
 	//-------------------------
 	//end of recursion
 	template<typename T, size_t DIM, size_t I>
-	typename std::enable_if< (I==DIM) && (std::is_integral<T>::value), void  >::type
+	requires ((I==DIM) && (std::integral<T>))
+	void
 	get_indexes(size_t , const T ( &)[DIM], T (&)[DIM])
 	{}
 
 	//begin of the recursion
 	template<typename T, size_t DIM, size_t I=0>
-	typename std::enable_if< (I<DIM) && (std::is_integral<T>::value), void  >::type
+	requires ((I<DIM) && (std::integral<T>))
+	void
 	get_indexes(size_t index,const  T ( &depths)[DIM], T (&indexes)[DIM] )
 	{
 

--- a/hydra/detail/utility/LSB.h
+++ b/hydra/detail/utility/LSB.h
@@ -33,6 +33,7 @@
 #include <hydra/detail/utility/Integer.h>
 #include<type_traits>
 #include<utility>
+#include <concepts>
 
 namespace hydra {
 
@@ -49,12 +50,8 @@ namespace detail {
  * 64 bit implementation
  */
 template<typename Integer>
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-		std::is_integral<Integer>::value  &&
-    	!(std::is_signed<Integer>::value) &&
-    	(sizeof(Integer)==8)
-    , unsigned>::type
+requires (std::integral<Integer> && !(std::is_signed<Integer>::value) && (sizeof(Integer)==8))
+__hydra_host__ __hydra_device__ inline unsigned
 lsb( Integer x){
 
 	if(!x) return 64;
@@ -109,12 +106,8 @@ lsb( Integer x){
  * 32 bit implementation
  */
 template<typename Integer>
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-		std::is_integral<Integer>::value  &&
-    	!(std::is_signed<Integer>::value) &&
-    	(sizeof(Integer)==4)
-    , unsigned>::type
+requires (std::integral<Integer> && !(std::is_signed<Integer>::value) && (sizeof(Integer)==4))
+__hydra_host__ __hydra_device__ inline unsigned
 lsb( Integer x){
 
 	if(!x) return 32;

--- a/hydra/detail/utility/MSB.h
+++ b/hydra/detail/utility/MSB.h
@@ -33,6 +33,7 @@
 #include <hydra/detail/utility/Integer.h>
 #include <type_traits>
 #include<utility>
+#include <concepts>
 
 namespace hydra {
 
@@ -49,12 +50,12 @@ namespace detail {
  * 64 bit implementation
  */
 template<typename Integer>
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-		std::is_integral<Integer>::value  &&
-    	!(std::is_signed<Integer>::value) &&
-    	(std::numeric_limits<Integer>::digits==64)
-    , unsigned>::type
+requires (
+	std::integral<Integer> &&
+	!(std::is_signed<Integer>::value) &&
+	(std::numeric_limits<Integer>::digits==64)
+)
+__hydra_host__ __hydra_device__ inline unsigned
 msb( Integer x){
 
 	if(!x) return 64;
@@ -100,12 +101,12 @@ msb( Integer x){
  * 32 bit implementation
  */
 template<typename Integer>
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-		std::is_integral<Integer>::value  &&
-    	!(std::is_signed<Integer>::value) &&
-    	(std::numeric_limits<Integer>::digits<=32)
-    , unsigned>::type
+requires (
+	std::integral<Integer> &&
+	!(std::is_signed<Integer>::value) &&
+	(std::numeric_limits<Integer>::digits<=32)
+)
+__hydra_host__ __hydra_device__ inline unsigned
 msb( Integer x){
 
 	if(!x) return 32;
@@ -146,12 +147,8 @@ msb( Integer x){
  */
 /*
 template<typename Integer>
-__hydra_host__ __hydra_device__
-inline typename std::enable_if<
-		std::is_integral<Integer>::value  &&
-    	!(std::is_signed<Integer>::value) &&
-    	(std::numeric_limits<Integer>::digits==16)
-    , unsigned>::type
+requires (std::integral<Integer> && !(std::is_signed<Integer>::value) && (std::numeric_limits<Integer>::digits==16))
+__hydra_host__ __hydra_device__ inline unsigned
 msb( Integer const& x){
 
 	if(!x) return 16;

--- a/hydra/detail/utility/Permutation.h
+++ b/hydra/detail/utility/Permutation.h
@@ -37,6 +37,7 @@
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
 #include <hydra/detail/external/hydra_thrust/swap.h>
 #include <hydra/detail/external/hydra_thrust/reverse.h>
+#include <concepts>
 
 namespace hydra {
 
@@ -77,7 +78,8 @@ Iterator rotate(Iterator first, Iterator n_first, Iterator last)
 }
 
 template<typename Iterator, typename Integer, typename Comparator>
-typename std::enable_if<std::is_integral<Integer>::value, void>::type
+requires (std::integral<Integer>)
+void
 __hydra_host__ __hydra_device__
 nth_permutation(Iterator begin, Iterator end, Integer n, Comparator comp)
 {

--- a/hydra/detail/utility/Permute.h
+++ b/hydra/detail/utility/Permute.h
@@ -34,6 +34,7 @@
 #include <hydra/detail/external/hydra_thrust/memory.h>
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
 #include <hydra/detail/external/hydra_thrust/swap.h>
+#include <concepts>
 
 namespace hydra {
 
@@ -77,7 +78,8 @@ using hydra::detail::iter_swap;
 }
 
 template<typename Iterator, typename Integer, typename Comparator>
-typename std::enable_if<std::is_integral<Integer>::value, void>::type
+requires (std::integral<Integer>)
+void
 __hydra_host__ __hydra_device__
 nth_permutation(Iterator begin, Iterator end, Integer n, Comparator comp)
 {

--- a/hydra/detail/utility/StreamSTL.h
+++ b/hydra/detail/utility/StreamSTL.h
@@ -43,12 +43,14 @@ namespace hydra {
 
 /** array streamer helper **/
 template<  size_t N, typename T, size_t I>
-inline typename std::enable_if<(I==N), void>::type
+requires ((I==N))
+inline void
 stream_array_helper(std::ostream& , std::array<T,N> const& )
 { }
 
 template< size_t N, typename T, size_t I=0>
-inline typename std::enable_if< (I < N), void>::type
+requires ((I < N))
+inline void
 stream_array_helper(std::ostream& os, std::array<T,N> const&  obj)
 {
  char separator = (I==N-1)?char(0):',';
@@ -70,12 +72,14 @@ inline std::ostream& operator<<(std::ostream& os, std::array<T, N> const&  obj)
 
 /** tuple streamer helper **/
 template<size_t I, typename ...T>
-inline typename std::enable_if<(I==sizeof ...(T)), void>::type
+requires ((I==sizeof ...(T)))
+inline void
 stream_tuple_helper(std::ostream& , std::tuple<T...> const&  )
 { }
 
 template<size_t I=0, typename ...T>
-inline typename std::enable_if< (I < sizeof ...(T)), void>::type
+requires ((I < sizeof ...(T)))
+inline void
  stream_tuple_helper(std::ostream& os, std::tuple<T...> const&  obj)
 {
  char separator = (I==sizeof ...(T)-1)?char(0):char(',');

--- a/hydra/detail/utility/Utility_Tuple.h
+++ b/hydra/detail/utility/Utility_Tuple.h
@@ -50,6 +50,31 @@ namespace hydra {
 
 	namespace detail {
 
+	// -----------------------------------------------------------------------
+	// Helper concepts to express the recursion / validity constraints of the
+	// tuple utilities below more concisely.
+	// -----------------------------------------------------------------------
+
+	// compile-time recursion guards (base case / recursive step)
+	template<size_t I, size_t Bound>
+	concept LoopEnd = (I == Bound);
+
+	template<size_t I, size_t Bound>
+	concept LoopGoing = (I < Bound);
+
+	// every type in Ts... is convertible to Target
+	template<typename Target, typename... Ts>
+	concept AllConvertibleTo = (std::is_convertible_v<Ts, Target> && ...);
+
+	// every type in Head, Tail... is the same
+	template<typename Head, typename... Tail>
+	concept AllSame = are_all_same<Head, Tail...>::value;
+
+	// usable as an accumulation result (real or complex)
+	template<typename T>
+	concept Accumulable = std::is_convertible_v<T, double> ||
+	                      std::is_constructible_v<hydra::thrust::complex<double>, T>;
+
 	//---------------------------------------
 	// get the type of a tuple with a given the type and the number of elements
     /*
@@ -111,13 +136,13 @@ namespace hydra {
 
 	//--------------------------------------
 	template<typename T, typename C, size_t N, size_t I>
-	__hydra_host__  __hydra_device__ inline
-	typename std::enable_if< I==N,void>::type
+	requires LoopEnd<I, N>
+	__hydra_host__ __hydra_device__ inline void
 	max_helper( T const&, C&, size_t&){}
 
 	template<typename T, typename C, size_t N, size_t I=1>
-	__hydra_host__  __hydra_device__ inline
-	typename std::enable_if< I < N, void>::type
+	requires LoopGoing<I, N>
+	__hydra_host__ __hydra_device__ inline void
 	max_helper( T const& tuple, C& max_value, size_t& max_index){
 
 	 max_index = max_value > hydra::thrust::get<I>(tuple) ? max_index : I;
@@ -197,14 +222,14 @@ namespace hydra {
 	//---------------------------------------------
 	// get a reference to a tuple object by index
 	template<typename R, typename T, size_t I>
-	__hydra_host__  __hydra_device__ inline
-	typename hydra::thrust::detail::enable_if<(I == hydra::thrust::tuple_size<T>::value), void>::type
+	requires LoopEnd<I, hydra::thrust::tuple_size<T>::value>
+	__hydra_host__ __hydra_device__ inline void
 	_get_element(const size_t , T& , R*&  )
 	{ }
 
 	template<typename R, typename T, size_t I=0>
-	__hydra_host__  __hydra_device__ inline
-	typename hydra::thrust::detail::enable_if<( I < hydra::thrust::tuple_size<T>::value), void>::type
+	requires LoopGoing<I, hydra::thrust::tuple_size<T>::value>
+	__hydra_host__ __hydra_device__ inline void
 	_get_element(const size_t index, T& t, R*& ptr )
 	{
 
@@ -382,22 +407,14 @@ namespace hydra {
 	//---------------------------------------
 	// set a generic array with tuple values
 	template<size_t I, typename ArrayType, typename FistType, typename ...OtherTypes>
-	__hydra_host__  __hydra_device__
-	inline typename hydra::thrust::detail::enable_if<
-		I == (sizeof...(OtherTypes) + 1) &&
-		std::is_convertible<FistType, ArrayType>::value &&
-		all_true< std::is_convertible<OtherTypes,ArrayType>::value...>::value,
-	void >::type
+	requires (LoopEnd<I, sizeof...(OtherTypes) + 1> && AllConvertibleTo<ArrayType, FistType, OtherTypes...>)
+	__hydra_host__ __hydra_device__ inline void
 	assignArrayToTuple(hydra::thrust::tuple<FistType, OtherTypes...> &,  ArrayType const*)
 	{}
 
 	template<size_t I = 0, typename ArrayType, typename FistType, typename ...OtherTypes>
-	__hydra_host__  __hydra_device__
-	inline typename hydra::thrust::detail::enable_if<
-	(I < sizeof...(OtherTypes)+1) &&
-	std::is_convertible<FistType, ArrayType>::value &&
-	all_true< std::is_convertible<OtherTypes,ArrayType>::value...>::value,
-	void >::type
+	requires (LoopGoing<I, sizeof...(OtherTypes)+1> && AllConvertibleTo<ArrayType, FistType, OtherTypes...>)
+	__hydra_host__ __hydra_device__ inline void
 	assignArrayToTuple(hydra::thrust::tuple<FistType, OtherTypes...>& t, ArrayType const* Array )
 	{
 		hydra::thrust::get<I>(t) =  Array[I];
@@ -408,22 +425,14 @@ namespace hydra {
 	// set a generic array with tuple values
 	/*
 	template<size_t I,  typename ArrayType, typename FistType, typename ...OtherTypes>
-	__hydra_host__  __hydra_device__
-	inline typename hydra::thrust::detail::enable_if<
-		I == (sizeof...(OtherTypes) + 1) &&
-		std::is_convertible<ArrayType, FistType>::value &&
-		all_true< std::is_convertible<ArrayType,OtherTypes>::value...>::value,
-	void>::type
+	requires (LoopEnd<I, sizeof...(OtherTypes) + 1> && std::is_convertible_v<ArrayType, FistType>::value && all_true< std::is_convertible_v<ArrayType,OtherTypes>::value...>::value)
+	__hydra_host__ __hydra_device__ inline void
 	assignArrayToTuple(hydra::thrust::tuple<FistType, OtherTypes...> &,  ArrayType* )
 	{}
 
 	template<size_t I = 0, typename ArrayType, typename FistType, typename ...OtherTypes>
-	__hydra_host__  __hydra_device__
-	inline typename hydra::thrust::detail::enable_if<
-		(I < sizeof...(OtherTypes)+1) &&
-		std::is_convertible<ArrayType, FistType>::value &&
-		all_true< std::is_convertible<ArrayType,OtherTypes>::value...>::value,
-	void >::type
+	requires (LoopGoing<I, sizeof...(OtherTypes)+1> && std::is_convertible_v<ArrayType, FistType>::value && all_true< std::is_convertible_v<ArrayType,OtherTypes>::value...>::value)
+	__hydra_host__ __hydra_device__ inline void
 	assignArrayToTuple(hydra::thrust::tuple<FistType, OtherTypes...> & t, ArrayType* Array )
 	{
 		hydra::thrust::get<I>(t) = (typename ArrayType::args_type) Array[I];
@@ -432,22 +441,14 @@ namespace hydra {
 */
 	//---------------------------------------
 	template<size_t I,  typename ArrayType, typename FistType, typename ...OtherTypes>
-	__hydra_host__  __hydra_device__
-	inline typename hydra::thrust::detail::enable_if<
-	I == (sizeof...(OtherTypes) + 1) &&
-	std::is_convertible<FistType,ArrayType >::value &&
-	all_true<std::is_convertible<OtherTypes,ArrayType>::value...>::value,
-	void>::type
+	requires (LoopEnd<I, sizeof...(OtherTypes) + 1> && AllConvertibleTo<ArrayType, FistType, OtherTypes...>)
+	__hydra_host__ __hydra_device__ inline void
 	assignArrayToTuple(hydra::thrust::detail::tuple_of_iterator_references<FistType, OtherTypes...> &,  ArrayType const* )
 	{}
 
 	template<size_t I = 0, typename ArrayType, typename FistType, typename ...OtherTypes>
-	__hydra_host__  __hydra_device__
-	inline typename hydra::thrust::detail::enable_if<
-	(I < sizeof...(OtherTypes)+1) &&
-	std::is_convertible<FistType,ArrayType >::value &&
-	all_true<std::is_convertible<OtherTypes,ArrayType>::value...>::value,
-	void >::type
+	requires (LoopGoing<I, sizeof...(OtherTypes)+1> && AllConvertibleTo<ArrayType, FistType, OtherTypes...>)
+	__hydra_host__ __hydra_device__ inline void
 	assignArrayToTuple(hydra::thrust::detail::tuple_of_iterator_references<FistType, OtherTypes...> & t, ArrayType const* Array )
 	{
 		hydra::thrust::get<I>(t) =  Array[I];
@@ -456,14 +457,14 @@ namespace hydra {
 	//---------------------------------------
 	// set a std::array with tuple values
 	 template<size_t I = 0, typename FistType, typename ...OtherTypes>
-	 inline typename hydra::thrust::detail::enable_if<I == (sizeof...(OtherTypes) + 1) &&
-	              are_all_same<FistType,OtherTypes...>::value, void>::type
+	 requires (LoopEnd<I, sizeof...(OtherTypes) + 1> && AllSame<FistType,OtherTypes...>)
+	 inline void
 	 tupleToArray(hydra::thrust::tuple<FistType, OtherTypes...> const&, std::array<FistType, sizeof...(OtherTypes) + 1>&)
 	 {}
 
 	 template<size_t I = 0, typename FistType, typename ...OtherTypes>
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(OtherTypes)+1) &&
-	 are_all_same<FistType,OtherTypes...>::value, void >::type
+	 requires (LoopGoing<I, sizeof...(OtherTypes)+1> && AllSame<FistType,OtherTypes...>)
+	 inline void
 	 tupleToArray(hydra::thrust::tuple<FistType, OtherTypes...> const& t, std::array<FistType, sizeof...(OtherTypes) + 1>& Array)
 	 {
 
@@ -475,22 +476,14 @@ namespace hydra {
 	 //---------------------------------------
 	 // set a std::array with tuple values
 	 template<size_t I, typename Type, typename Head, typename ...Tail>
-	 __hydra_host__  __hydra_device__
-	 inline typename std::enable_if<
-	 (I == sizeof...(Tail) + 1) &&
-	 std::is_convertible< Head, Type>::value &&
-	 all_true<std::is_convertible<Tail, Type>::value ... >::value,
-	 void >::type
+	 requires (LoopEnd<I, sizeof...(Tail) + 1> && AllConvertibleTo<Type, Head, Tail...>)
+	 __hydra_host__ __hydra_device__ inline void
 	 assignTupleToArray(hydra::thrust::tuple<Head, Tail...> const&, Type(&)[sizeof...(Tail)+1])
 	 { }
 
 	 template<size_t I = 0, typename Type, typename Head, typename ...Tail>
-	 __hydra_host__  __hydra_device__
-	 inline typename std::enable_if<
-	 	 (I < sizeof...(Tail) + 1) &&
-	 	 std::is_convertible< Head, Type>::value &&
-	 	 all_true<std::is_convertible<Tail, Type>::value ... >::value,
-	 void >::type
+	 requires (LoopGoing<I, sizeof...(Tail) + 1> && AllConvertibleTo<Type, Head, Tail...>)
+	 __hydra_host__ __hydra_device__ inline void
 	 assignTupleToArray(hydra::thrust::tuple<Head, Tail...> const& Tuple, Type (&Array)[sizeof...(Tail)+1])
 	 {
 
@@ -501,22 +494,14 @@ namespace hydra {
 	 //-----------------
 	 // set a std::array with tuple values
 	 template<size_t I, typename Type, typename Head, typename ...Tail>
-	 __hydra_host__  __hydra_device__
-	 inline typename std::enable_if<
-	 (I == sizeof...(Tail) + 1) &&
-	 std::is_convertible< Head, Type>::value &&
-	 all_true<std::is_convertible<Tail, Type>::value ... >::value,
-	 void >::type
+	 requires (LoopEnd<I, sizeof...(Tail) + 1> && AllConvertibleTo<Type, Head, Tail...>)
+	 __hydra_host__ __hydra_device__ inline void
 	 assignTupleToArray(hydra::thrust::tuple<Head, Tail...> const&, std::array<Type, sizeof...(Tail)+1>&)
 	 { }
 
 	 template<size_t I = 0, typename Type, typename Head, typename ...Tail>
-	 __hydra_host__  __hydra_device__
-	 inline typename std::enable_if<
-	 (I < sizeof...(Tail) + 1) &&
-	 std::is_convertible< Head, Type>::value &&
-	 all_true<std::is_convertible<Tail, Type>::value ... >::value,
-	 void >::type
+	 requires (LoopGoing<I, sizeof...(Tail) + 1> && AllConvertibleTo<Type, Head, Tail...>)
+	 __hydra_host__ __hydra_device__ inline void
 	 assignTupleToArray(hydra::thrust::tuple<Head, Tail...> const& Tuple, std::array<Type, sizeof...(Tail)+1>& Array)
 	 {
 
@@ -527,22 +512,14 @@ namespace hydra {
 	 //---------------------------------------
 	 // set a std::array with tuple values
 	 template<size_t I, typename Type, typename Head, typename ...Tail>
-	 __hydra_host__  __hydra_device__
-	 inline typename std::enable_if<
-	 (I == sizeof...(Tail) + 1) &&
-	 std::is_convertible< typename remove_device_reference<Head>::type, Type>::value &&
-	 all_true<std::is_convertible< typename remove_device_reference<Tail>::type, Type>::value ... >::value,
-	 void >::type
+	 requires (LoopEnd<I, sizeof...(Tail) + 1> && std::is_convertible_v< typename remove_device_reference<Head>::type, Type> && all_true<std::is_convertible_v< typename remove_device_reference<Tail>::type, Type> ... >::value)
+	 __hydra_host__ __hydra_device__ inline void
 	 assignTupleToArray(hydra::thrust::detail::tuple_of_iterator_references<Head, Tail...> const&, Type(&)[sizeof...(Tail)+1])
 	 { }
 
 	 template<size_t I = 0, typename Type, typename Head, typename ...Tail>
-	 __hydra_host__  __hydra_device__
-	 inline typename std::enable_if<
-	 (I < sizeof...(Tail) + 1) &&
-	 std::is_convertible< typename remove_device_reference<Head>::type, Type>::value &&
-	 all_true<std::is_convertible<typename remove_device_reference<Tail>::type, Type>::value ... >::value,
-	 void >::type
+	 requires (LoopGoing<I, sizeof...(Tail) + 1> && std::is_convertible_v< typename remove_device_reference<Head>::type, Type> && all_true<std::is_convertible_v<typename remove_device_reference<Tail>::type, Type> ... >::value)
+	 __hydra_host__ __hydra_device__ inline void
 	 assignTupleToArray(hydra::thrust::detail::tuple_of_iterator_references<Head, Tail...> const& Tuple, Type (&Array)[sizeof...(Tail)+1])
 	 {
 
@@ -553,22 +530,14 @@ namespace hydra {
 	 //-----------------
 	 // set a std::array with tuple values
 	 template<size_t I, typename Type, typename Head, typename ...Tail>
-	 __hydra_host__  __hydra_device__
-	 inline typename std::enable_if<
-	 (I == sizeof...(Tail) + 1) &&
-	 std::is_convertible< typename remove_device_reference<Head>::type, Type>::value &&
-	 all_true<std::is_convertible<typename remove_device_reference<Tail>::type, Type>::value ... >::value,
-	 void >::type
+	 requires (LoopEnd<I, sizeof...(Tail) + 1> && std::is_convertible_v< typename remove_device_reference<Head>::type, Type> && all_true<std::is_convertible_v<typename remove_device_reference<Tail>::type, Type> ... >::value)
+	 __hydra_host__ __hydra_device__ inline void
 	 assignTupleToArray(hydra::thrust::detail::tuple_of_iterator_references<Head, Tail...> const&, std::array<Type, sizeof...(Tail)+1>&)
 	 { }
 
 	 template<size_t I = 0, typename Type, typename Head, typename ...Tail>
-	 __hydra_host__  __hydra_device__
-	 inline typename std::enable_if<
-	 (I < sizeof...(Tail) + 1) &&
-	 std::is_convertible< typename remove_device_reference<Head>::type, Type>::value &&
-	 all_true<std::is_convertible<typename remove_device_reference<Tail>::type, Type>::value ... >::value,
-	 void >::type
+	 requires (LoopGoing<I, sizeof...(Tail) + 1> && std::is_convertible_v< typename remove_device_reference<Head>::type, Type> && all_true<std::is_convertible_v<typename remove_device_reference<Tail>::type, Type> ... >::value)
+	 __hydra_host__ __hydra_device__ inline void
 	 assignTupleToArray(hydra::thrust::detail::tuple_of_iterator_references<Head, Tail...> const& Tuple, std::array<Type, sizeof...(Tail)+1>& Array)
 	 {
 
@@ -580,16 +549,14 @@ namespace hydra {
 	 //---------------------------------------
 	 // set a generic array with tuple values
 	 template<size_t I = 0, typename FistType, typename ...OtherTypes>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == (sizeof...(OtherTypes) + 1) &&
-	              are_all_same<FistType,OtherTypes...>::value, void>::type
+	 requires (LoopEnd<I, sizeof...(OtherTypes) + 1> && AllSame<FistType,OtherTypes...>)
+	 __hydra_host__ __hydra_device__ inline void
 	 tupleToArray(hydra::thrust::tuple<FistType, OtherTypes...> const &,  typename std::remove_reference<FistType>::type*)
 	 {}
 
 	 template<size_t I = 0, typename FistType, typename ...OtherTypes>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(OtherTypes)+1) &&
-	           are_all_same<FistType,OtherTypes...>::value, void >::type
+	 requires (LoopGoing<I, sizeof...(OtherTypes)+1> && AllSame<FistType,OtherTypes...>)
+	 __hydra_host__ __hydra_device__ inline void
 	 tupleToArray(hydra::thrust::tuple<FistType, OtherTypes...> const & t,  typename std::remove_reference<FistType>::type* Array)
 	 {
 
@@ -602,13 +569,13 @@ namespace hydra {
 	 namespace utils {
 
 			 template<typename TupleType, typename ArrayType, size_t I>
-			 __hydra_host__  __hydra_device__
-			 inline typename hydra::thrust::detail::enable_if<I == hydra::thrust::tuple_size<TupleType>::value, void >::type
+			 requires LoopEnd<I, hydra::thrust::tuple_size<TupleType>::value>
+			 __hydra_host__ __hydra_device__ inline void
 			_tuple_to_array(TupleType const& , ArrayType* ){ }
 
 			 template<typename TupleType, typename ArrayType, size_t I=0>
-			 __hydra_host__  __hydra_device__
-			 inline typename hydra::thrust::detail::enable_if<I < hydra::thrust::tuple_size<TupleType>::value, void >::type
+			 requires LoopGoing<I, hydra::thrust::tuple_size<TupleType>::value>
+			 __hydra_host__ __hydra_device__ inline void
 			 _tuple_to_array(TupleType const & _tuple,  ArrayType* _array) {
 
 				 _array[I] = hydra::thrust::get<I>( _tuple);
@@ -618,11 +585,11 @@ namespace hydra {
 	}  // namespace utils
 	 // entry point
 	 template<typename TupleType, typename ArrayType>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<
-	 	(detail::is_instantiation_of<hydra::thrust::tuple,TupleType>::value ||
-	 	 detail::is_instantiation_of<hydra::thrust::detail::tuple_of_iterator_references, TupleType>::value),
-	 void>::type tupleToArray(TupleType const& _tuple,  ArrayType* _array){
+	 requires (
+		(detail::is_instantiation_of<hydra::thrust::tuple,TupleType>::value) ||
+		(detail::is_instantiation_of<hydra::thrust::detail::tuple_of_iterator_references, TupleType>::value)
+	)
+	 __hydra_host__ __hydra_device__ inline void tupleToArray(TupleType const& _tuple,  ArrayType* _array){
 
 		 utils::_tuple_to_array(_tuple, _array);
 	 }
@@ -653,14 +620,14 @@ namespace hydra {
 
 	 // set array of pointers to point to the tuple elements
 	 template<size_t I= 0, typename Array_Type, typename T>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I == hydra::thrust::tuple_size<T>::value) && is_homogeneous<Array_Type, T>::value, void>::type
+	 requires (LoopEnd<I, hydra::thrust::tuple_size<T>::value> && is_homogeneous<Array_Type, T>::value)
+	 __hydra_host__ __hydra_device__ inline void
 	 set_ptrs_to_tuple(T& , Array_Type** )
 	 {}
 
 	 template<size_t I = 0, typename Array_Type, typename T>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < hydra::thrust::tuple_size<T>::value) && is_homogeneous<Array_Type, T>::value, void>::type
+	 requires (LoopGoing<I, hydra::thrust::tuple_size<T>::value> && is_homogeneous<Array_Type, T>::value)
+	 __hydra_host__ __hydra_device__ inline void
 	 set_ptrs_to_tuple(T& t, Array_Type** Array)
 	 {
 		 Array[I] =  &hydra::thrust::get<I>(t);
@@ -672,19 +639,23 @@ namespace hydra {
 
 
      template<typename T1, typename  T2>
-     void ptr_setter( T1*& ptr, typename hydra::thrust::detail::enable_if<hydra::thrust::detail::is_same<T1,T2>::value, T2 >::type* el ){ ptr=el; }
+     requires (hydra::thrust::detail::is_same<T1,T2>::value)
+     void ptr_setter( T1*& ptr, T2* el ){ ptr=el; }
 
      template<typename T1, typename  T2>
-     void ptr_setter( T1*&, typename hydra::thrust::detail::enable_if<!hydra::thrust::detail::is_same<T1,T2>::value, T2 >::type* ){  }
+     requires (!hydra::thrust::detail::is_same<T1,T2>::value)
+     void ptr_setter( T1*&, T2* ){  }
 
 
      template<unsigned int I, typename Ptr, typename ...Tp>
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+     requires LoopEnd<I, sizeof...(Tp)>
+     inline void
 	 set_ptr_to_tuple_element(const int, std::tuple<Tp...>&, Ptr*&)
 	 {	 }
 
 	 template<unsigned int I = 0, typename Ptr, typename ...Tp>
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)), void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 inline void
 	 set_ptr_to_tuple_element(const  int index, std::tuple<Tp...> & t, Ptr*& ptr)
 	 {
 		 if(index == I ) ptr_setter<Ptr, typename std::tuple_element<I, std::tuple<Tp...>>::type>( ptr, &std::get<I>(t));
@@ -696,14 +667,14 @@ namespace hydra {
      //---------------------------------------
 	 //get a element of a given tuple by index. value is stored in x
 	 template<unsigned int I = 0, typename T, typename ...Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 get_tuple_element(const int, hydra::thrust::tuple<Tp...> const&, T& )
 	 {}
 
 	 template<unsigned int I = 0, typename T, typename ...Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)), void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 get_tuple_element(const  int index, hydra::thrust::tuple<Tp...> const& t, T& x)
 	 {
 		 if(index == I)x=T(  hydra::thrust::get<I>(t));
@@ -714,14 +685,14 @@ namespace hydra {
 	 //---------------------------------------
 	 //set a element of a given tuple by index to value  x
 	 template<unsigned int I = 0, typename T, typename ...Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 set_tuple_element(const int, hydra::thrust::tuple<Tp...> const&, T& )
 	 {}
 
 	 template<unsigned int I = 0, typename T, typename ...Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)), void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 set_tuple_element(const  int index, hydra::thrust::tuple<Tp...>& t, const T& x)
 	 {
 		 if(index == I) hydra::thrust::get<I>(t)=x;
@@ -732,14 +703,14 @@ namespace hydra {
 	 // evaluate a void functor taking as argument
 	 // a given tuple element
 	 template<unsigned int I = 0, typename FuncT, typename ...Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 eval_on_tuple_element(int, hydra::thrust::tuple<Tp...> const&, FuncT const&)
 	 {}
 
 	 template<unsigned int I = 0, typename FuncT, typename ...Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)), void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 eval_on_tuple_element(int index, hydra::thrust::tuple<Tp...> const& t, FuncT const& f)
 	 {
 		 if (index == 0) std::forward<FuncT const>(f)(hydra::thrust::get<I>(t));
@@ -752,14 +723,14 @@ namespace hydra {
 	 // arg and return on r
 	 //--------------------------------------
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 eval_tuple_element(Return_Type&, int, hydra::thrust::tuple<Tp...> const&, ArgType const&)
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)), void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 eval_tuple_element(Return_Type& r, int index, hydra::thrust::tuple<Tp...> const& t, ArgType const& arg)
 	 {
 		 if (index == 0)
@@ -775,14 +746,14 @@ namespace hydra {
 	 // element taking as argument ArgType const&
 	 // arg and return on r
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 sum_tuple(Return_Type&, hydra::thrust::tuple<Tp...>&&, ArgType&&)
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)), void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 sum_tuple(Return_Type& r, hydra::thrust::tuple<Tp...>&& t, ArgType&& arg)
 	 {
 		 r = r+ (Return_Type) hydra::thrust::get<I>( std::forward<hydra::thrust::tuple<Tp...>>(t))(std::forward<ArgType>(arg));
@@ -791,14 +762,14 @@ namespace hydra {
 
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 sum_tuple(Return_Type&, hydra::thrust::tuple<Tp...> const&, ArgType const&)
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)), void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 sum_tuple(Return_Type& r, hydra::thrust::tuple<Tp...>const& t, ArgType const& arg)
 	 {
 		 r = r+ (Return_Type) hydra::thrust::get<I>(t)(arg);
@@ -807,14 +778,14 @@ namespace hydra {
 
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType1, typename ArgType2, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 sum_tuple2(Return_Type&, hydra::thrust::tuple<Tp...>&&, ArgType1&&, ArgType2&& )
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType1, typename ArgType2, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)), void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 sum_tuple2(Return_Type& r, hydra::thrust::tuple<Tp...>&& t, ArgType1&& arg1, ArgType2&& arg2)
 	 {
 		 r = r + (Return_Type) hydra::thrust::get<I>(t)(arg1, arg2);
@@ -823,14 +794,14 @@ namespace hydra {
 	 }
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType1, typename ArgType2, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 sum_tuple2(Return_Type&, hydra::thrust::tuple<Tp...>const&, ArgType1 const&, ArgType2 const& )
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType1, typename ArgType2, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)), void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 sum_tuple2(Return_Type& r, hydra::thrust::tuple<Tp...> const& t, ArgType1 const& arg1, ArgType2 const& arg2)
 	 {
 		 r = r + (Return_Type) hydra::thrust::get<I>(t)(arg1, arg2);
@@ -843,14 +814,14 @@ namespace hydra {
 	 // element taking as argument ArgType &
 	 // arg and return on r
 	 template<size_t I = 0, typename Return_Type,  typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 multiply_tuple(Return_Type&, hydra::thrust::tuple<Tp...> const&)
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)),void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 multiply_tuple(Return_Type& r, hydra::thrust::tuple<Tp...>const& t)
 	 {
 		 r = r*( (Return_Type) hydra::thrust::get<I>(t));
@@ -858,14 +829,14 @@ namespace hydra {
 	 }
 
 	 template<size_t I = 0, typename Return_Type,  typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 multiply_tuple(Return_Type&, hydra::thrust::tuple<Tp...>&&)
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)),void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 multiply_tuple(Return_Type& r, hydra::thrust::tuple<Tp...>&& t)
 	 {
 		 r = r*( (Return_Type) hydra::thrust::get<I>(std::forward< hydra::thrust::tuple<Tp...> >(t)));
@@ -873,14 +844,14 @@ namespace hydra {
 	 }
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple(Return_Type&, hydra::thrust::tuple<Tp...> const&, ArgType const&)
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)),void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple(Return_Type& r, hydra::thrust::tuple<Tp...> const& t, ArgType const& arg)
 	 {
 		 r = r*( (Return_Type) hydra::thrust::get<I>(t)(arg));
@@ -889,14 +860,14 @@ namespace hydra {
 
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple(Return_Type&, hydra::thrust::tuple<Tp...> &&, ArgType&&)
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)),void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple(Return_Type& r, hydra::thrust::tuple<Tp...>&& t, ArgType&& arg)
 	 {
 		 r = r*( (Return_Type) hydra::thrust::get<I>(std::forward< hydra::thrust::tuple<Tp...> >(t))(std::forward<ArgType>(arg)));
@@ -904,14 +875,14 @@ namespace hydra {
 	 }
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType1, typename ArgType2, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple2(Return_Type&, hydra::thrust::tuple<Tp...> const&, ArgType1  const&, ArgType2 const&)
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType1, typename ArgType2,  typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < (sizeof...(Tp))),void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple2(Return_Type& r, hydra::thrust::tuple<Tp...> const& t, ArgType1 const& arg1, ArgType2 const& arg2)
 	 {
 		 r = r*((Return_Type) hydra::thrust::get<I>(t)(arg1, arg2));
@@ -920,14 +891,14 @@ namespace hydra {
 
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType1, typename ArgType2, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple2(Return_Type&, hydra::thrust::tuple<Tp...>&&, ArgType1&&, ArgType2&&)
 	 {}
 
 	 template<size_t I = 0, typename Return_Type, typename ArgType1, typename ArgType2,  typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < (sizeof...(Tp))),void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple2(Return_Type& r, hydra::thrust::tuple<Tp...>&& t, ArgType1&& arg1, ArgType2&& arg2)
 	 {
 		 r = r*((Return_Type) hydra::thrust::get<I>(std::forward< hydra::thrust::tuple<Tp...> >(t))(std::forward<ArgType1>(arg1), std::forward<ArgType2>(arg2)));
@@ -936,14 +907,14 @@ namespace hydra {
 	 }
 
 	 template<size_t I = 0, size_t N,typename Return_Type, typename ArgType1, typename ArgType2, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == N, void>::type
+	 requires LoopEnd<I, N>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple3(Return_Type&, hydra::thrust::tuple<Tp...> const&, ArgType1 const&, ArgType2 const&)
 	 {}
 
 	 template<size_t I = 0,size_t N, typename Return_Type, typename ArgType1, typename ArgType2,  typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < N),void >::type
+	 requires LoopGoing<I, N>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple3(Return_Type& r, hydra::thrust::tuple<Tp...> const& t, ArgType1 const& arg1, ArgType2 const& arg2)
 	 {
 		 r = r*((Return_Type) hydra::thrust::get<I>(t)(arg1, arg2));
@@ -952,14 +923,14 @@ namespace hydra {
 
 
 	 template<size_t I = 0, size_t N,typename Return_Type, typename ArgType1, typename ArgType2, typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<I == N, void>::type
+	 requires LoopEnd<I, N>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple3(Return_Type&, hydra::thrust::tuple<Tp...>&&, ArgType1&&, ArgType2&&)
 	 {}
 
 	 template<size_t I = 0,size_t N, typename Return_Type, typename ArgType1, typename ArgType2,  typename ... Tp>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < N),void >::type
+	 requires LoopGoing<I, N>
+	 __hydra_host__ __hydra_device__ inline void
 	 product_tuple3(Return_Type& r, hydra::thrust::tuple<Tp...>&& t, ArgType1&& arg1, ArgType2&& arg2)
 	 {
 		 r = r*((Return_Type) hydra::thrust::get<I>(std::forward< hydra::thrust::tuple<Tp...> >(t))(std::forward<ArgType1>(arg1), std::forward<ArgType2>(arg2)));
@@ -1118,12 +1089,14 @@ namespace hydra {
 
 	 // set functors in tuple
 	 template<size_t I = 0, typename ... Tp>
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 inline void
 	 set_functors_in_tuple(hydra::thrust::tuple<Tp...>&, const std::vector<double>&)
 	 {}
 
 	 template<size_t I = 0, typename ... Tp>
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)),void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 inline void
 	 set_functors_in_tuple(hydra::thrust::tuple<Tp...>& t,  const std::vector<double>& parameters)
 	 {
 		 hydra::thrust::get<I>(t).SetParameters(parameters);
@@ -1132,12 +1105,14 @@ namespace hydra {
 
 
 	 template<size_t I = 0, typename ... Tp>
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 inline void
 	 print_parameters_in_tuple(hydra::thrust::tuple<Tp...>&)
 	 {}
 
 	 template<size_t I = 0, typename ... Tp>
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)),void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 inline void
 	 print_parameters_in_tuple(hydra::thrust::tuple<Tp...>& t)
 	 {
 		 hydra::thrust::get<I>(t).PrintRegisteredParameters();
@@ -1145,12 +1120,14 @@ namespace hydra {
 	 }
 
 	 template<size_t I=0, typename ... Tp>
-	 inline typename hydra::thrust::detail::enable_if<I == sizeof...(Tp), void>::type
+	 requires LoopEnd<I, sizeof...(Tp)>
+	 inline void
 	 add_parameters_in_tuple(std::vector<hydra::Parameter*>& , hydra::thrust::tuple<Tp...>&)
 	 {}
 
 	 template<size_t I = 0, typename ... Tp>
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(Tp)),void >::type
+	 requires LoopGoing<I, sizeof...(Tp)>
+	 inline void
 	 add_parameters_in_tuple(std::vector<hydra::Parameter*>& user_parameters, hydra::thrust::tuple<Tp...>& t)
 	 {
 		 hydra::thrust::get<I>(t).AddUserParameters(user_parameters);
@@ -1172,8 +1149,8 @@ namespace hydra {
 
 
 	 //accumulate by sum
-	 template<typename Return_Type, typename ArgType, typename ... Tp,
-	 typename=typename hydra::thrust::detail::enable_if<std::is_convertible<Return_Type, double>::value || std::is_constructible<hydra::thrust::complex<double>,Return_Type>::value >::type >
+	 template<typename Return_Type, typename ArgType, typename ... Tp>
+	 requires Accumulable<Return_Type>
 	 __hydra_host__  __hydra_device__
 	 inline Return_Type accumulate(ArgType& x, hydra::thrust::tuple<Tp...>& t)
 	 {
@@ -1182,8 +1159,8 @@ namespace hydra {
 		 return r;
 	 }
 
-	 template<typename Return_Type, typename ArgType, typename ... Tp,
-	 typename=typename hydra::thrust::detail::enable_if<std::is_convertible<Return_Type, double>::value || std::is_constructible<hydra::thrust::complex<double>,Return_Type>::value >::type >
+	 template<typename Return_Type, typename ArgType, typename ... Tp>
+	 requires Accumulable<Return_Type>
 	 __hydra_host__  __hydra_device__
 	 inline Return_Type accumulate(ArgType const& x, hydra::thrust::tuple<Tp...> const& t)
 	 {
@@ -1193,7 +1170,8 @@ namespace hydra {
 	 }
 
 	 template<typename Return_Type, typename ArgType1, typename ArgType2,
-	 typename ... Tp, typename=typename hydra::thrust::detail::enable_if<std::is_convertible<Return_Type, double>::value || std::is_constructible<hydra::thrust::complex<double>,Return_Type>::value>::type>
+	 typename ... Tp>
+	 requires Accumulable<Return_Type>
 	 __hydra_host__  __hydra_device__
 	 inline Return_Type accumulate2(ArgType1& x, ArgType2& y, hydra::thrust::tuple<Tp...>& t)
 	 {
@@ -1204,7 +1182,8 @@ namespace hydra {
 
 
 	 template<typename Return_Type, typename ArgType1, typename ArgType2,
-	 typename ... Tp, typename=typename hydra::thrust::detail::enable_if<std::is_convertible<Return_Type, double>::value || std::is_constructible<hydra::thrust::complex<double>,Return_Type>::value>::type>
+	 typename ... Tp>
+	 requires Accumulable<Return_Type>
 	 __hydra_host__  __hydra_device__
 	 inline Return_Type accumulate2(ArgType1 const& x, ArgType2 const& y, hydra::thrust::tuple<Tp...> const& t)
 	 {
@@ -1215,8 +1194,8 @@ namespace hydra {
 
 
 	 //accumulate by product
-	 template<typename Return_Type, typename ArgType, typename ... Tp,
-	 typename=typename hydra::thrust::detail::enable_if<std::is_convertible<Return_Type, double>::value || std::is_constructible<hydra::thrust::complex<double>,Return_Type>::value >::type>
+	 template<typename Return_Type, typename ArgType, typename ... Tp>
+	 requires Accumulable<Return_Type>
 	 __hydra_host__  __hydra_device__
 	 inline Return_Type product(ArgType const& x, hydra::thrust::tuple<Tp...>  const& t)
 	 {
@@ -1226,8 +1205,8 @@ namespace hydra {
 	 }
 
 	 //accumulate by product
-	 template<typename Return_Type, typename ArgType, typename ... Tp,
-	 typename=typename hydra::thrust::detail::enable_if<std::is_convertible<Return_Type, double>::value || std::is_constructible<hydra::thrust::complex<double>,Return_Type>::value >::type>
+	 template<typename Return_Type, typename ArgType, typename ... Tp>
+	 requires Accumulable<Return_Type>
 	 __hydra_host__  __hydra_device__
 	 inline Return_Type product(ArgType& x, hydra::thrust::tuple<Tp...> & t)
 	 {
@@ -1236,8 +1215,8 @@ namespace hydra {
 		 return r;
 	 }
 
-	 template<typename Return_Type, typename ArgType1,typename ArgType2, typename ... Tp,
-	 typename=typename hydra::thrust::detail::enable_if<std::is_convertible<Return_Type, double>::value || std::is_constructible<hydra::thrust::complex<double>,Return_Type>::value >::type>
+	 template<typename Return_Type, typename ArgType1,typename ArgType2, typename ... Tp>
+	 requires Accumulable<Return_Type>
 	 __hydra_host__  __hydra_device__
 	 inline Return_Type product2(ArgType1 const& x, ArgType2 const& y, hydra::thrust::tuple<Tp...> const& t)
 	 {
@@ -1247,8 +1226,8 @@ namespace hydra {
 		 return r;
 	 }
 
-	 template<typename Return_Type, typename ArgType1,typename ArgType2, typename ... Tp,
-	 typename=typename hydra::thrust::detail::enable_if<std::is_convertible<Return_Type, double>::value || std::is_constructible<hydra::thrust::complex<double>,Return_Type>::value >::type>
+	 template<typename Return_Type, typename ArgType1,typename ArgType2, typename ... Tp>
+	 requires Accumulable<Return_Type>
 	 __hydra_host__  __hydra_device__
 	 inline Return_Type product2(ArgType1& x, ArgType2& y, hydra::thrust::tuple<Tp...>& t)
 	 {
@@ -1259,14 +1238,14 @@ namespace hydra {
 	 }
 
 	 template<size_t I, typename ...T>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I == sizeof...(T)),void >::type
+	 requires LoopEnd<I, sizeof...(T)>
+	 __hydra_host__ __hydra_device__ inline void
 	 add_tuple_values(GReal_t& , hydra::thrust::tuple<T...> const&)
 	 { }
 
 	 template<size_t I=0, typename ...T>
-	 __hydra_host__  __hydra_device__
-	 inline typename hydra::thrust::detail::enable_if<(I < sizeof...(T)),void >::type
+	 requires LoopGoing<I, sizeof...(T)>
+	 __hydra_host__ __hydra_device__ inline void
      add_tuple_values(GReal_t& result, hydra::thrust::tuple<T...> const& tpl )
 	 {
 		 result += hydra::thrust::get<I>(tpl);

--- a/hydra/functions/Chebychev.h
+++ b/hydra/functions/Chebychev.h
@@ -133,13 +133,13 @@ public:
 private:
 
 	template<unsigned int I>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<(I==Order+1), void >::type
+	requires ((I==Order+1))
+	__hydra_host__ __hydra_device__ inline void
 	polynomial_helper( const double(&)[Order+1],  const double, double&)  const {}
 
 	template<unsigned int I=0>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<(I<Order+1), void >::type
+	requires ((I<Order+1))
+	__hydra_host__ __hydra_device__ inline void
 	polynomial_helper( const double(&coef)[Order+1],  const double x, double& r)  const {
 
 		r += coef[I]*chebychev_1st_kind(I, x);
@@ -194,13 +194,13 @@ protected:
 private:
 
 	template<unsigned int N, unsigned int I>
-	__hydra_host__ __hydra_device__ inline
-	typename std::enable_if<(I==N), void >::type
+	requires ((I==N))
+	__hydra_host__ __hydra_device__ inline void
 	polynomial_integral_helper( const double, const double(&)[N], double&) const {}
 
 	template<unsigned int N, unsigned int I=2>
-	__hydra_host__ __hydra_device__ inline
-	typename std::enable_if<(I<N), void >::type
+	requires ((I<N))
+	__hydra_host__ __hydra_device__ inline void
 	polynomial_integral_helper( const double x, const double(&coef)[N], double& r) const {
 
 		r += 0.5*coef[I]*(chebychev_1st_kind(I+1,x)/(I+1) - chebychev_1st_kind(I-1,x)/(I-1) );

--- a/hydra/functions/ConvolutionFunctor.h
+++ b/hydra/functions/ConvolutionFunctor.h
@@ -42,6 +42,7 @@
 #include <hydra/detail/FFTPolicy.h>
 #include <hydra/detail/external/hydra_thrust/iterator/iterator_traits.h>
 #include <type_traits>
+#include <concepts>
 
 
 namespace hydra {
@@ -356,7 +357,8 @@ private:
 
 
 	template<detail::FFTCalculator FFTC=FFT>
-	inline typename std::enable_if<FFTC ==detail::CuFFT>::type
+	requires (FFTC ==detail::CuFFT)
+	inline void
 	sync_data()
 	{
 		hydra::thrust::copy_n( fFFTData, fNSamples, fDeviceData );
@@ -364,7 +366,8 @@ private:
 	}
 
 	template<detail::FFTCalculator FFTC=FFT>
-	inline typename std::enable_if<FFTC !=detail::CuFFT>::type
+	requires (FFTC !=detail::CuFFT)
+	inline void
 	sync_data()
 	{
 		hydra::thrust::copy_n(device_system_type(), fFFTData, fNSamples, fDeviceData );
@@ -386,8 +389,9 @@ private:
 
 template<typename ArgType,  typename Functor, typename Kernel, detail::Backend BACKEND, detail::FFTCalculator FFT,
                typename T=typename detail::stripped_type<typename std::common_type<typename Functor::return_type, typename Kernel::return_type>::type>::type>
-inline typename std::enable_if< std::is_floating_point<T>::value, ConvolutionFunctor<Functor, Kernel,
-                 detail::BackendPolicy<BACKEND>, detail::FFTPolicy<T, FFT>, ArgType>>::type
+requires (std::floating_point<T>)
+inline ConvolutionFunctor<Functor, Kernel,
+                 detail::BackendPolicy<BACKEND>, detail::FFTPolicy<T, FFT>, ArgType>
 make_convolution( detail::BackendPolicy<BACKEND> const&, detail::FFTPolicy<T, FFT> const&, Functor const& functor, Kernel const& kernel,
 		T kmin, T kmax, unsigned nsamples=1024,	bool interpolate=true, bool power_up=true)
 {

--- a/hydra/functions/Polynomial.h
+++ b/hydra/functions/Polynomial.h
@@ -119,13 +119,13 @@ private:
 
 
 	template<int I>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<(I==-1), void >::type
+	requires ((I==-1))
+	__hydra_host__ __hydra_device__ inline void
 	polynomial_helper( const double(&)[Order+1],  const double, double&)  const {}
 
 	template<int I>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< (I < Order) &&( I>=0), void >::type
+	requires ((I < Order) &&( I>=0))
+	__hydra_host__ __hydra_device__ inline void
 	polynomial_helper( const double(&coef)[Order+1],  const double x, double& p)  const {
 
 		 p = p*x + coef[I];
@@ -133,8 +133,8 @@ private:
 	}
 
 	template<int I=Order>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if< I==(Order), void >::type
+	requires (I==(Order))
+	__hydra_host__ __hydra_device__ inline void
 	polynomial_helper( const double(&coef)[Order+1],  const double x, double& p)  const {
 
 		  p=coef[I];
@@ -174,13 +174,13 @@ protected:
 private:
 
 	template<unsigned int N, unsigned int I>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<(I==N), void >::type
+	requires ((I==N))
+	__hydra_host__ __hydra_device__ inline void
 	polynomial_integral_helper( const double, const double(&)[N], double&) const {}
 
 	template<unsigned int N, unsigned int I=0>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<(I<N), void >::type
+	requires ((I<N))
+	__hydra_host__ __hydra_device__ inline void
 	polynomial_integral_helper( const double x, const double(&coef)[N], double& r) const {
 
 		r += coef[I]*hydra::pow<double,I+1>(x)/(I+1);

--- a/hydra/functions/Spline2DFunctor.h
+++ b/hydra/functions/Spline2DFunctor.h
@@ -48,6 +48,7 @@
 #include <math.h>
 #include <algorithm>
 #include <memory>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -163,12 +164,13 @@ make_spline2D(IteratorX firstX, IteratorX lastX, IteratorY firstY, IteratorY las
 }
 
 template<typename ArgTypeX, typename ArgTypeY, typename IterableX, typename IterableY, typename IterableZ >
-inline typename std::enable_if<
-          hydra::detail::is_iterable<IterableX>::value &&
-		  hydra::detail::is_iterable<IterableY>::value &&
-		  hydra::detail::is_iterable<IterableZ>::value,
-          Spline2DFunctor< decltype(std::declval<IterableX>().begin()) ,decltype(std::declval<IterableY>().begin()),
-                          decltype(std::declval<IterableZ>().begin()), ArgTypeX, ArgTypeY> >::type
+requires (
+	hydra::detail::Iterable<IterableX> &&
+	hydra::detail::Iterable<IterableY> &&
+	hydra::detail::Iterable<IterableZ>
+)
+inline Spline2DFunctor< decltype(std::declval<IterableX>().begin()) ,decltype(std::declval<IterableY>().begin()),
+                          decltype(std::declval<IterableZ>().begin()), ArgTypeX, ArgTypeY>
 make_spline2D(IterableX&& x, IterableY&& y, IterableZ&& z)
 {
 
@@ -186,11 +188,11 @@ typedef  decltype(std::declval<IterableZ>().begin()) IteratorZ;
 
 
 template<typename T, hydra::detail::Backend BACKEND>
-inline typename std::enable_if< std::is_convertible<T, double>::value,
-Spline2DFunctor<
+requires (std::is_convertible_v<T, double>)
+inline Spline2DFunctor<
 decltype(std::declval<DenseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_0).begin()),
 decltype(std::declval<DenseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_1).begin()),
-decltype(std::declval<DenseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()), double, double>>::type
+decltype(std::declval<DenseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()), double, double>
 make_spline( DenseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional >  const& histogram )
 {
 
@@ -209,11 +211,11 @@ typedef  decltype(std::declval<histogram_type>().GetBinsContents().begin()) Iter
 
 
 template<typename T, hydra::detail::Backend BACKEND>
-inline typename std::enable_if< std::is_convertible<T, double>::value,
-Spline2DFunctor<
+requires (std::is_convertible_v<T, double>)
+inline Spline2DFunctor<
 decltype(std::declval<SparseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_0).begin()),
 decltype(std::declval<SparseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_1).begin()),
-decltype(std::declval<SparseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()), double, double>>::type
+decltype(std::declval<SparseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()), double, double>
 make_spline( SparseHistogram<T, 2,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional >  const& histogram )
 {
 

--- a/hydra/functions/Spline3DFunctor.h
+++ b/hydra/functions/Spline3DFunctor.h
@@ -48,6 +48,7 @@
 #include <math.h>
 #include <algorithm>
 #include <memory>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -184,13 +185,14 @@ make_spline3D(IteratorX firstX, IteratorX lastX, IteratorY firstY, IteratorY las
 }
 
 template<typename ArgTypeX, typename ArgTypeY,typename ArgTypeZ, typename IterableX, typename IterableY, typename IterableZ, typename IterableM >
-inline typename std::enable_if<
-          hydra::detail::is_iterable<IterableX>::value &&
-		  hydra::detail::is_iterable<IterableY>::value &&
-		  hydra::detail::is_iterable<IterableZ>::value &&
-		  hydra::detail::is_iterable<IterableM>::value,
-          Spline3DFunctor< decltype(std::declval<IterableX>().begin()) ,decltype(std::declval<IterableY>().begin()),
-                          decltype(std::declval<IterableZ>().begin()), decltype(std::declval<IterableM>().begin()), ArgTypeX, ArgTypeY, ArgTypeZ> >::type
+requires (
+	hydra::detail::Iterable<IterableX> &&
+	hydra::detail::Iterable<IterableY> &&
+	hydra::detail::Iterable<IterableZ> &&
+	hydra::detail::Iterable<IterableM>
+)
+inline Spline3DFunctor< decltype(std::declval<IterableX>().begin()) ,decltype(std::declval<IterableY>().begin()),
+                          decltype(std::declval<IterableZ>().begin()), decltype(std::declval<IterableM>().begin()), ArgTypeX, ArgTypeY, ArgTypeZ>
 make_spline3D(IterableX&& x, IterableY&& y, IterableZ&& z, IterableM&& measurements)
 {
 
@@ -212,12 +214,12 @@ typedef  decltype(std::declval<IterableM>().begin()) IteratorM;
 
 
 template<typename T, hydra::detail::Backend BACKEND>
-inline typename std::enable_if< std::is_convertible<T, double>::value,
-Spline3DFunctor<
+requires (std::is_convertible_v<T, double>)
+inline Spline3DFunctor<
 decltype(std::declval<DenseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_0).begin()),
 decltype(std::declval<DenseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_1).begin()),
 decltype(std::declval<DenseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_2).begin()),
-decltype(std::declval<DenseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()), double, double, double>>::type
+decltype(std::declval<DenseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()), double, double, double>
 make_spline( DenseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional >  const& histogram )
 {
 
@@ -238,12 +240,12 @@ typedef  decltype(std::declval<histogram_type>().GetBinsContents().begin()) Iter
 
 
 template<typename T, hydra::detail::Backend BACKEND>
-inline typename std::enable_if< std::is_convertible<T, double>::value,
-Spline3DFunctor<
+requires (std::is_convertible_v<T, double>)
+inline Spline3DFunctor<
 decltype(std::declval<SparseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_0).begin()),
 decltype(std::declval<SparseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_1).begin()),
 decltype(std::declval<SparseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_2).begin()),
-decltype(std::declval<SparseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()), double, double, double>>::type
+decltype(std::declval<SparseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()), double, double, double>
 make_spline( SparseHistogram<T, 3,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional >  const& histogram )
 {
 

--- a/hydra/functions/Spline4DFunctor.h
+++ b/hydra/functions/Spline4DFunctor.h
@@ -48,6 +48,7 @@
 #include <math.h>
 #include <algorithm>
 #include <memory>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -224,19 +225,20 @@ make_spline4D(IteratorX firstX, IteratorX lastX,
 template<typename ArgTypeX, typename ArgTypeY, typename ArgTypeW, typename ArgTypeZ,
          typename IterableX, typename IterableY, typename IterableW, typename IterableZ,
 		 typename IterableM >
-inline typename std::enable_if<
-          hydra::detail::is_iterable<IterableX>::value &&
-		  hydra::detail::is_iterable<IterableY>::value &&
-		  hydra::detail::is_iterable<IterableW>::value &&
-		  hydra::detail::is_iterable<IterableZ>::value &&
-		  hydra::detail::is_iterable<IterableM>::value,
-          Spline4DFunctor<
+requires (
+	hydra::detail::Iterable<IterableX> &&
+	hydra::detail::Iterable<IterableY> &&
+	hydra::detail::Iterable<IterableW> &&
+	hydra::detail::Iterable<IterableZ> &&
+	hydra::detail::Iterable<IterableM>
+)
+inline Spline4DFunctor<
 		   decltype(std::declval<IterableX>().begin()),
 		   decltype(std::declval<IterableY>().begin()),
 		   decltype(std::declval<IterableW>().begin()),
            decltype(std::declval<IterableZ>().begin()),
 		   decltype(std::declval<IterableM>().begin()),
-		   ArgTypeX, ArgTypeY, ArgTypeW, ArgTypeZ> >::type
+		   ArgTypeX, ArgTypeY, ArgTypeW, ArgTypeZ>
 make_spline4D(IterableX&& x, IterableY&& y, IterableW&& w, IterableZ&& z, IterableM&& measurements)
 {
 
@@ -257,14 +259,14 @@ typedef  decltype(std::declval<IterableM>().begin()) IteratorM;
 
 
 template<typename T, hydra::detail::Backend BACKEND>
-inline typename std::enable_if< std::is_convertible<T, double>::value,
-Spline4DFunctor<
+requires (std::is_convertible_v<T, double>)
+inline Spline4DFunctor<
 decltype(std::declval<DenseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_0).begin()),
 decltype(std::declval<DenseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_1).begin()),
 decltype(std::declval<DenseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_2).begin()),
 decltype(std::declval<DenseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_3).begin()),
 decltype(std::declval<DenseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()),
-double, double, double, double>>::type
+double, double, double, double>
 make_spline( DenseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional >  const& histogram ){
 
 typedef  DenseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > histogram_type;
@@ -286,14 +288,14 @@ typedef  decltype(std::declval<histogram_type>().GetBinsContents().begin()) Iter
 
 
 template<typename T, hydra::detail::Backend BACKEND>
-inline typename std::enable_if< std::is_convertible<T, double>::value,
-Spline4DFunctor<
+requires (std::is_convertible_v<T, double>)
+inline Spline4DFunctor<
 decltype(std::declval<SparseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_0).begin()),
 decltype(std::declval<SparseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_1).begin()),
 decltype(std::declval<SparseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_2).begin()),
 decltype(std::declval<SparseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional> >().GetBinsCenters(placeholders::_3).begin()),
 decltype(std::declval<SparseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > >().GetBinsContents().begin()),
-double, double, double, double>>::type
+double, double, double, double>
 make_spline( SparseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional >  const& histogram ){
 
 typedef  SparseHistogram<T, 4,  hydra::detail::BackendPolicy<BACKEND>, detail::multidimensional > histogram_type;

--- a/hydra/functions/SplineFunctor.h
+++ b/hydra/functions/SplineFunctor.h
@@ -48,6 +48,7 @@
 #include <math.h>
 #include <algorithm>
 #include <memory>
+#include <hydra/detail/IteratorConcepts.h>
 
 namespace hydra {
 
@@ -158,11 +159,9 @@ make_spline(Iterator1 firstX, Iterator1 lastX, Iterator2 firstY )
 }
 
 template<typename ArgType, typename Iterable1, typename Iterable2 >
-inline typename std::enable_if<
-          hydra::detail::is_iterable<Iterable1>::value &&
-          hydra::detail::is_iterable<Iterable2>::value,
-          SplineFunctor< decltype(std::declval<Iterable1>().begin()),
-                          decltype(std::declval<Iterable2>().begin()), ArgType> >::type
+requires (hydra::detail::Iterable<Iterable1> && hydra::detail::Iterable<Iterable2>)
+inline SplineFunctor< decltype(std::declval<Iterable1>().begin()),
+                          decltype(std::declval<Iterable2>().begin()), ArgType>
 make_spline(Iterable1&& x, Iterable2&& y)
 {
 

--- a/hydra/functions/Utils.h
+++ b/hydra/functions/Utils.h
@@ -67,14 +67,14 @@ namespace detail {
 
 
 	template<typename T, unsigned int N, unsigned int I>
-	__hydra_host__ __hydra_device__
-	inline typename std::enable_if<I==N, void >::type
+	requires (I==N)
+	__hydra_host__ __hydra_device__ inline void
 	pow_helper(T const, T&){}
 
 
 	template<typename T, unsigned int N, unsigned int I>
-	inline __hydra_host__ __hydra_device__
-	typename std::enable_if< (I< N), void >::type
+	requires ((I< N))
+	inline __hydra_host__ __hydra_device__ void
 	pow_helper(T const x, T& r){
 		r *= x ;
 		pow_helper<T,N,I+1>(x,r);

--- a/hydra/multiarray.h
+++ b/hydra/multiarray.h
@@ -47,6 +47,8 @@
 #include <hydra/detail/external/hydra_thrust/functional.h>
 #include <hydra/detail/external/hydra_thrust/detail/type_traits.h>
 #include <hydra/detail/external/hydra_thrust/iterator/transform_iterator.h>
+#include <hydra/detail/IteratorConcepts.h>
+#include <concepts>
 
 
 namespace hydra {
@@ -132,7 +134,8 @@ public:
 		hydra::thrust::fill(begin(), end(), value );
 	}
 
-	template<typename Int, typename = typename hydra::thrust::detail::enable_if<std::is_integral<Int>::value>::type >
+	template<typename Int>
+	requires (std::integral<Int>)
 	multiarray(hydra::pair<Int, typename detail::tuple_type<N, T>::type > const& pair){
 		__resize(pair.first);
 		hydra::thrust::fill(begin(), end(), pair.second );
@@ -163,12 +166,8 @@ public:
 		hydra::thrust::copy(first, last, begin());
 	}
 
-	template< typename Iterable,
-	          typename = typename std::enable_if<
-	           (detail::is_iterable<Iterable>::value) &&
-	          !(detail::is_iterator<Iterable>::value) &&
-	           (std::is_convertible<decltype(*std::declval<Iterable>().begin()), value_type>::value)
-	          >::type >
+	template< typename Iterable>
+	requires ((hydra::detail::Iterable<Iterable>) && !(detail::is_iterator<Iterable>::value) && (std::is_convertible<decltype(*std::declval<Iterable>().begin()), value_type>::value))
 	multiarray(Iterable&& other )
 	{
 		__resize( hydra::thrust::distance(
@@ -291,8 +290,8 @@ public:
 
 
 	template< typename InputIterator>
-	inline typename hydra::thrust::detail::enable_if<
-	 detail::is_instantiation_of< hydra::thrust::zip_iterator, InputIterator>::value, void>::type
+	requires (detail::is_instantiation_of< hydra::thrust::zip_iterator, InputIterator>::value)
+	inline void
 	insert(iterator pos, InputIterator first, InputIterator last)
 	{
 		size_type position = hydra::thrust::distance(begin(), pos);
@@ -708,11 +707,13 @@ private:
 	//__________________________________________
 	// pop_back
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__pop_back(){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__pop_back()
 	{
 		std::get<I>(fData).pop_back();
@@ -722,11 +723,13 @@ private:
 	//__________________________________________
 	// resize
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__resize(size_type){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__resize(size_type n)
 	{
 		std::get<I>(fData).resize(n);
@@ -736,11 +739,13 @@ private:
 	//__________________________________________
 	// push_back
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__push_back( value_type const& ){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__push_back( value_type const& value )
 	{
 		std::get<I>(fData).push_back( hydra::thrust::get<I>(value) );
@@ -750,11 +755,13 @@ private:
 	//__________________________________________
 	// clear
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__clear(){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__clear( )
 	{
 		std::get<I>(fData).clear();
@@ -764,11 +771,13 @@ private:
 	//__________________________________________
 	// shrink_to_fit
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__shrink_to_fit(){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__shrink_to_fit( )
 	{
 		std::get<I>(fData).shrink_to_fit();
@@ -778,11 +787,13 @@ private:
 	//__________________________________________
 	// shrink_to_fit
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__reserve(size_type ){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__reserve(size_type size )
 	{
 		std::get<I>(fData).reserve(size);
@@ -792,11 +803,13 @@ private:
 	//__________________________________________
 	// erase
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void>::type
+	requires ((I == N))
+	inline void
 	__erase_helper( size_type ){ }
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void>::type
+	requires ((I < N))
+	inline void
 	__erase_helper(size_type position )
 	{
 		std::get<I>(fData).erase(
@@ -815,11 +828,13 @@ private:
 	// erase
 
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void>::type
+	requires ((I == N))
+	inline void
 	__erase_helper( size_type ,  size_type ){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void>::type
+	requires ((I < N))
+	inline void
 	__erase_helper( size_type first_position,  size_type last_position)
 	{
 		std::get<I>(fData).erase(
@@ -839,11 +854,13 @@ private:
 	//__________________________________________
 	// insert
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__insert_helper( size_type ,  const value_type&){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__insert_helper( size_type position,  const value_type &x)
 	{
 		std::get<I>(fData).insert(
@@ -863,11 +880,13 @@ private:
 	//__________________________________________
 	// insert
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__insert_helper( size_type , size_type , const value_type&){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__insert_helper( size_type position, size_type n, const value_type &x)
 	{
 		std::get<I>(fData).insert(
@@ -885,11 +904,13 @@ private:
 	//__________________________________________
 	// insert
 	template<size_t I,typename InputIterator >
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__insert(size_type, InputIterator const&, InputIterator const& ){}
 
 	template<size_t I=0,typename InputIterator >
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__insert(size_type position, InputIterator const& first, InputIterator const& last  )
 	{
 		std::get<I>(fData).insert(std::get<I>(fData).begin() + position,

--- a/hydra/multivector.h
+++ b/hydra/multivector.h
@@ -50,6 +50,8 @@
 #include <hydra/detail/external/hydra_thrust/detail/type_traits.h>
 #include <hydra/detail/external/hydra_thrust/iterator/transform_iterator.h>
 #include <array>
+#include <hydra/detail/IteratorConcepts.h>
+#include <concepts>
 
 
 namespace hydra {
@@ -174,7 +176,8 @@ public:
 	 * Constructor initializing the multivector with \p n copies of \p value .
 	 * @param pair hydra::pair<size_t, hydra::tuple<T...> >  object to copy from.
 	 */
-	template<typename Int, typename = typename hydra::thrust::detail::enable_if<std::is_integral<Int>::value>::type >
+	template<typename Int>
+	requires (std::integral<Int>)
 	multivector(hydra::pair<Int, hydra::thrust::tuple<T...> > const& pair)
 	{
 		__resize(pair.first);
@@ -224,12 +227,8 @@ public:
 		hydra::thrust::copy(first, last, begin());
 
 	}
-	template< typename Iterable,
-	          typename = typename std::enable_if<
-	           (detail::is_iterable<Iterable>::value) &&
-	          !(detail::is_iterator<Iterable>::value) &&
-	           (std::is_convertible<decltype(*std::declval<Iterable>().begin()), value_type>::value)
-	          >::type >
+	template< typename Iterable>
+	requires ((hydra::detail::Iterable<Iterable>) && !(detail::is_iterator<Iterable>::value) && (std::is_convertible<decltype(*std::declval<Iterable>().begin()), value_type>::value))
 	multivector(Iterable&& other )
 	{
 		__resize( hydra::thrust::distance(
@@ -434,10 +433,8 @@ public:
      *                        and \p InputIterator's \c value_type is a model of <a href="http://www.sgi.com/tech/stl/Assignable.html">Assignable</a>.
      */
 	template< typename InputIterator>
-	inline 	typename hydra::thrust::detail::enable_if<
-	detail::is_zip_iterator<InputIterator>::value &&
-	std::is_convertible<typename hydra::thrust::iterator_traits<InputIterator>::value_type,
-	value_type>::value, void>::type
+	requires (detail::is_zip_iterator<InputIterator>::value && std::is_convertible<typename hydra::thrust::iterator_traits<InputIterator>::value_type, value_type>::value)
+	inline void
 	insert(iterator pos, InputIterator first, InputIterator last)
 	{
 		size_type position = hydra::thrust::distance(begin(), pos);
@@ -827,9 +824,9 @@ public:
 
 
 	template<typename ...Iterables>
+	requires (hydra::detail::Iterable<Iterables> && ...)
 	auto meld( Iterables&& ...iterables)
-	-> typename std::enable_if<detail::all_true<detail::is_iterable<Iterables>::value...>::value,
-	hydra::Range<decltype(detail::meld_iterators(begin(), std::forward<Iterables>(iterables).begin()... ))>>::type
+	-> hydra::Range<decltype(detail::meld_iterators(begin(), std::forward<Iterables>(iterables).begin()... ))>
 	{
 			auto first = detail::meld_iterators(begin(), std::forward<Iterables>(iterables).begin()... );
 			auto last  = detail::meld_iterators(end(), std::forward<Iterables>(iterables).end()... );
@@ -913,11 +910,13 @@ private:
 	//__________________________________________
 	// pop_back
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__pop_back(){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__pop_back()
 	{
 		 hydra::thrust::get<I>(fData).pop_back();
@@ -928,11 +927,13 @@ private:
 	//__________________________________________
 	// resize
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__resize(size_type){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__resize(size_type n)
 	{
 		hydra::thrust::get<I>(fData).resize(n);
@@ -942,11 +943,13 @@ private:
 	//__________________________________________
 	// push_back
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__push_back( value_type const& ){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__push_back( value_type const& value )
 	{
 		hydra::thrust::get<I>(fData).push_back( hydra::thrust::get<I>(value) );
@@ -956,11 +959,13 @@ private:
 	//__________________________________________
 	// clear
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__clear(){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__clear( )
 	{
 		hydra::thrust::get<I>(fData).clear();
@@ -970,11 +975,13 @@ private:
 	//__________________________________________
 	// shrink_to_fit
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__shrink_to_fit(){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__shrink_to_fit( )
 	{
 		hydra::thrust::get<I>(fData).shrink_to_fit();
@@ -984,11 +991,13 @@ private:
 	//__________________________________________
 	// shrink_to_fit
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__reserve(size_type ){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__reserve(size_type size )
 	{
 		hydra::thrust::get<I>(fData).reserve(size);
@@ -998,11 +1007,13 @@ private:
 	//__________________________________________
 	// erase
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void>::type
+	requires ((I == N))
+	inline void
 	__erase_helper( size_type ){ }
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void>::type
+	requires ((I < N))
+	inline void
 	__erase_helper(size_type position )
 	{
 		hydra::thrust::get<I>(fData).erase(
@@ -1021,11 +1032,13 @@ private:
 	// erase
 
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void>::type
+	requires ((I == N))
+	inline void
 	__erase_helper( size_type ,  size_type ){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void>::type
+	requires ((I < N))
+	inline void
 	__erase_helper( size_type first_position,  size_type last_position)
 	{
 		hydra::thrust::get<I>(fData).erase(
@@ -1045,11 +1058,13 @@ private:
 	//__________________________________________
 	// insert
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__insert_helper( size_type ,  const value_type&){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__insert_helper( size_type position,  const value_type &x)
 	{
 		hydra::thrust::get<I>(fData).insert(
@@ -1069,11 +1084,13 @@ private:
 	//__________________________________________
 	// insert
 	template<size_t I>
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__insert_helper( size_type, size_type, const value_type & ){}
 
 	template<size_t I=0>
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__insert_helper( size_type position, size_type n, const value_type &x)
 	{
 		hydra::thrust::get<I>(fData).insert(
@@ -1091,11 +1108,13 @@ private:
 	//__________________________________________
 	// insert
 	template<size_t I,typename InputIterator >
-	 inline typename hydra::thrust::detail::enable_if<(I == N), void >::type
+	requires ((I == N))
+	inline void
 	__insert(size_type , InputIterator , InputIterator  ){}
 
 	template<size_t I=0,typename InputIterator >
-	 inline typename hydra::thrust::detail::enable_if<(I < N), void >::type
+	requires ((I < N))
+	inline void
 	__insert(size_type position, InputIterator first, InputIterator last  )
 	{
 		hydra::thrust::get<I>(fData).insert(hydra::thrust::get<I>(fData).begin() + position,


### PR DESCRIPTION
We start to implement C++20 concepts in Hydra, in order to replace many verbose constraints on template arguments introduced in the past mainly to take benefit of SFINAE rule.