### PR TITLE
Fixed operand order in declarg operator overloads

### DIFF
--- a/hydra/detail/FunctionArgument.h
+++ b/hydra/detail/FunctionArgument.h
@@ -339,7 +339,7 @@ operator+( Arg1 const& a1, Arg2 const& a2) {
 
 template<typename Arg1, typename Arg2>
 requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
-__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()+  std::declval<Arg2>() )
+__hydra_host__ __hydra_device__ decltype(std::declval<Arg2>()+  std::declval<typename  Arg1::value_type>() )
 operator+(Arg2 const& a2, Arg1 const& a1 ) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()+
@@ -376,13 +376,13 @@ operator-( Arg1 const& a1, Arg2 const& a2) {
 
 template<typename Arg1, typename Arg2>
 requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
-__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()-  std::declval<Arg2>() )
+__hydra_host__ __hydra_device__ decltype(std::declval<Arg2>()-  std::declval<typename  Arg1::value_type>() )
 operator-(Arg2 const& a2, Arg1 const& a1 ) {
 
 	typedef decltype(std::declval<typename  Arg1::value_type>()-
 			 std::declval<Arg2>() ) return_type;
 
-	return a1.Value() - a2;
+	return a2 - a1.Value();
 }
 
 template<typename Arg1, typename Arg2>
@@ -405,7 +405,7 @@ requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
 __hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()* std::declval<Arg2>() )
 operator*( Arg1 const& a1, Arg2 const& a2) {
 
-	typedef decltype(std::declval<typename  Arg1::value_type>()-
+	typedef decltype(std::declval<typename  Arg1::value_type>()*
 			 std::declval<Arg2>() ) return_type;
 
 	return a1.Value() * a2;
@@ -413,10 +413,10 @@ operator*( Arg1 const& a1, Arg2 const& a2) {
 
 template<typename Arg1, typename Arg2>
 requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
-__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>()*  std::declval<Arg2>() )
+__hydra_host__ __hydra_device__ decltype(std::declval<Arg2>()*  std::declval<typename  Arg1::value_type>() )
 operator*(Arg2 const& a2, Arg1 const& a1 ) {
 
-	typedef decltype(std::declval<typename  Arg1::value_type>()-
+	typedef decltype(std::declval<typename  Arg1::value_type>()*
 			 std::declval<Arg2>() ) return_type;
 
 	return a1.Value() * a2;
@@ -441,7 +441,7 @@ requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
 __hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>() / std::declval<Arg2>() )
 operator/( Arg1 const& a1, Arg2 const& a2) {
 
-	typedef decltype(std::declval<typename  Arg1::value_type>()-
+	typedef decltype(std::declval<typename  Arg1::value_type>()/
 			 std::declval<Arg2>() ) return_type;
 
 	return a1.Value() / a2;
@@ -449,13 +449,13 @@ operator/( Arg1 const& a1, Arg2 const& a2) {
 
 template<typename Arg1, typename Arg2>
 requires (detail::FunctionArg<Arg1> && !detail::FunctionArg<Arg2>)
-__hydra_host__ __hydra_device__ decltype(std::declval<typename  Arg1::value_type>() / std::declval<Arg2>() )
+__hydra_host__ __hydra_device__ decltype(std::declval<Arg2>() / std::declval<typename  Arg1::value_type>() )
 operator/(Arg2 const& a2, Arg1 const& a1 ) {
 
-	typedef decltype(std::declval<typename  Arg1::value_type>()-
+	typedef decltype(std::declval<typename  Arg1::value_type>()/
 			 std::declval<Arg2>() ) return_type;
 
-	return a1.Value() / a2;
+	return a2 / a1.Value();
 }
 
 template<typename Arg1, typename Arg2>


### PR DESCRIPTION
While testing the `NewtonianNoise` repository, that uses Hydra as main dependency, I hit silently wrong numerical results traced to `hydra/detail/FunctionArgument.h`: the operator overloads for `declarg` types were correct for the commutative operators, but `-` and `/` operators returned the reciprocal of the intended values.

Changes:
- Fix the two reversed bodies: `a2 - a1.Value()` and `a2 / a1.Value()`.
- Fix the reversed overloads' declared return-type operand order (Arg2 @ Arg1::value_type).

Verified with a minimal local reproducer; existing test suite passes.